### PR TITLE
A0-2629: Bump GitHub actions validator from 0.4.2 to 0.4.3 to fix runs on

### DIFF
--- a/yaml-validate/action.yml
+++ b/yaml-validate/action.yml
@@ -10,7 +10,7 @@ runs:
 
     - name: VALIDATE | Execute github-actions-validator
       env:
-        DOCKER_IMAGE: public.ecr.aws/p6e8q1z1/github-actions-validator:0.4.3
+        DOCKER_IMAGE: public.ecr.aws/p6e8q1z1/github-actions-validator:v0.4.3
       shell: bash
       run: |
         set +e

--- a/yaml-validate/action.yml
+++ b/yaml-validate/action.yml
@@ -10,7 +10,7 @@ runs:
 
     - name: VALIDATE | Execute github-actions-validator
       env:
-        DOCKER_IMAGE: public.ecr.aws/p6e8q1z1/github-actions-validator:0.4.2
+        DOCKER_IMAGE: public.ecr.aws/p6e8q1z1/github-actions-validator:0.4.3
       shell: bash
       run: |
         set +e

--- a/yaml-validate/action.yml
+++ b/yaml-validate/action.yml
@@ -10,7 +10,7 @@ runs:
 
     - name: VALIDATE | Execute github-actions-validator
       env:
-        DOCKER_IMAGE: public.ecr.aws/p6e8q1z1/github-actions-validator:0.4.1
+        DOCKER_IMAGE: public.ecr.aws/p6e8q1z1/github-actions-validator:0.4.2
       shell: bash
       run: |
         set +e


### PR DESCRIPTION
The following works like charm:
````
docker run --name tmp-dupa -v $(pwd):/gh public.ecr.aws/p6e8q1z1/github-actions-validator:v0.4.3 validate -p /gh
````