### PR TITLE
A0-3204: Add featurenet actions from aleph-node repo

### DIFF
--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -1,0 +1,211 @@
+---
+name: Create featurenet
+description: |
+  This action several flows
+  * spawns new feature net bootstraped from PR, node binary is test one (short session)
+  * spawns new update net from a node image that is on ECR, prpduction one (normal session)
+  * upgrades feature net binary to a given version
+inputs:
+  gh-ci-token:
+    description: 'GH token to be used in the action'
+    required: true
+  repo-featurenets-name:
+    description: 'Name of the repository containing featurenets manifests'
+    required: true
+  argo-host:
+    description: 'ArgoCD host'
+    required: true
+  argo-sync-user-token:
+    description: 'ArgoCD user token to be used in the action'
+    required: true
+  ecr-public-registry:
+    description: "ECR public registry, with slash at the end, eg. 'public.ecr.aws/something/'"
+    required: true
+  featurenet-keys-s3bucket-name:
+    description: 'S3 bucket name with featurenet keys'
+    required: true
+  featurenet-name:
+    description: 'Enter name instead of getting it from branch'
+    required: false
+    default: ''
+  featurenet-aleph-node-image:
+    description: |
+      Set feature net image either to:
+       * 'testnet' or 'mainnet' - to Testnet or Mainnet image respectively,
+       * a 7 byte SHA - to exisiting ECR aleph-node image tag
+       * empty value - to image built from PR
+    required: false
+    default: ''
+  expiration:
+    description: 'Time after which updatenet will be removed'
+    required: false
+    default: ''
+  rolling-update-partition:
+    description: |
+      Number from 0 to N-1, where N is size of am existing feature net.
+      All aleph-node-validator-N with an ordinal N that is great than or equal to the partition
+      will be updated. If not specified, all nodes will be updated.
+    required: false
+    default: "0"
+  replicas:
+    description: |
+      Number of pods to start, from 0 to 50.
+    required: false
+    default: "5"
+  append-run-id-to-name:
+    description: |
+      When 'true' then run ID will be appended to featurenet name
+    required: false
+    default: "false"
+  internal:
+    description: 'Internal network, accessible from VPN only'
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      shell: bash
+      run: |
+        if [[
+          "${{ inputs.featurenet-name }}" != "" && \
+          ! "${{ inputs.featurenet-name }}" =~ ^[a-z0-9][a-z0-9\-]{4,30}$
+        ]]
+        then
+          echo "!!! Invalid feature net name"
+          exit 1
+        fi
+        if [[
+          "${{ inputs.featurenet-aleph-node-image }}" != "" && \
+          ! "${{ inputs.featurenet-aleph-node-image }}" =~ ^[a-f0-9]{7}$ && \
+          "${{ inputs.featurenet-aleph-node-image }}" != "testnet" && \
+          "${{ inputs.featurenet-aleph-node-image }}" != "mainnet"
+        ]]
+        then
+          echo "!!! Invalid feature net node image tag"
+          exit 1
+        fi
+        if [[
+          "${{ inputs.rolling-update-partition }}" != "" && \
+          ! "${{ inputs.rolling-update-partition }}" =~ ^[0-9]$
+        ]]
+        then
+          echo "!!! Expected rolling update partition to be a cardinal value from 0 to 9"
+          exit 1
+        fi
+        if [[
+          "${{ inputs.replicas }}" != "" && \
+          ! "${{ inputs.replicas }}" =~ ^[0-9]{1,2}$ || "${{ inputs.replicas }}" -gt 50
+        ]]
+        then
+          echo "!!! Expected replicas to be a cardinal value from 0 to 50"
+          exit 1
+        fi
+        if [[
+          "${{ inputs.expiration }}" != "" && \
+          ! "${{ inputs.expiration }}" =~ ^[0-9]{1,6}h$ && \
+          "${{ inputs.expiration }}" != "never"
+        ]]
+        then
+          echo "!!! Expected expiration to have values from set {3h, 12h, 24h, 48h, 96h, never}"
+          exit 1
+        fi
+
+    - name: Get branch name and commit SHA
+      id: get-ref-properties
+      uses: Cardinal-Cryptography/github-actions/get-ref-properties@v1
+
+    - name: Checkout featurenets repo
+      uses: actions/checkout@v3
+      with:
+        repository: Cardinal-Cryptography/${{ inputs.repo-featurenets-name }}
+        token: ${{ inputs.gh-ci-token }}
+        path: "${{ inputs.repo-featurenets-name }}"
+        ref: main
+
+    - name: Get argocd featurenet app name
+      id: get-argocd-featurnet-app-name
+      shell: bash
+      # yamllint disable rule:line-length
+      env:
+        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
+        APP_NAME_WITH_RUN_ID: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}-{2}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo, github.run_id) }}
+      run: |
+        name_local=${{ inputs.append-run-id-to-name == 'true' && env.APP_NAME_WITH_RUN_ID || env.APP_NAME }}
+        echo "name=$name_local" >> $GITHUB_OUTPUT
+      # yamllint enable rule:line-length
+
+    - name: Get node commit SHA
+      if: ${{ inputs.featurenet-aleph-node-image == 'testnet' ||
+        inputs.featurenet-aleph-node-image == 'mainnet' }}
+      id: get-node-commit-sha
+      uses: Cardinal-Cryptography/github-actions/get-node-system-version@v1
+      with:
+        env: ${{ inputs.featurenet-aleph-node-image }}
+
+    - name: Start featurenet from PR branch
+      shell: bash
+      env:
+        OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-featurenets-name }}"
+      # yamllint disable rule:line-length
+      run: |
+        cd "${{ inputs.repo-featurenets-name }}"
+        # featurenet creation from commit from PR
+        if [[ "${{ inputs.featurenet-aleph-node-image }}" == "" ]]; then
+          pr_image_tag="fe-${{ steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
+          fnet_aleph_node_image="${{ inputs.ecr-public-registry }}feature-env-aleph-node:${pr_image_tag}"
+          fnet_bootstrap_chain_node_image="${{ steps.get-ref-properties.outputs.sha }}"
+          fnet_create_hook="false"
+        # updatenet creation from Testnet or Mainnet image
+        elif [[ "${{ inputs.featurenet-aleph-node-image }}" == "testnet" || \
+            "${{ inputs.featurenet-aleph-node-image }}" == "mainnet" ]]; then
+          ecr_image_tag="${{ steps.get-node-commit-sha.outputs.sha }}"
+          fnet_aleph_node_image="${{ inputs.ecr-public-registry }}aleph-node:${ecr_image_tag}"
+          fnet_bootstrap_chain_node_image="${{ inputs.featurenet-aleph-node-image }}"
+          fnet_create_hook="false"
+        # updatenet update, ie updating binary to given version and runtime update
+        else
+          fnet_aleph_node_image="${{ inputs.ecr-public-registry }}aleph-node:${{ inputs.featurenet-aleph-node-image }}"
+          fnet_bootstrap_chain_node_image="none"
+          # Disabling hook here as work in progress
+          fnet_create_hook="false"
+        fi
+        ./Ops.sh create-featurenet-using-kustomize \
+          "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \
+          "${fnet_aleph_node_image}" \
+          "${fnet_bootstrap_chain_node_image}" \
+          "${{ inputs.rolling-update-partition }}" \
+          "${fnet_create_hook}" \
+          "${{ inputs.replicas }}" \
+          "${{ inputs.internal == 'true' && 'true' || 'false' }}"
+      # yamllint enable rule:line-length
+
+    - name: Set featurenet expiration
+      if: inputs.expiration != ''
+      shell: bash
+      env:
+        OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-featurenets-name }}"
+      run: |
+        cd "${{ inputs.repo-featurenets-name }}"
+        ./Ops.sh create-featurenet-expiration \
+          "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \
+          "${{ inputs.expiration }}"
+
+    - name: Commit featurenet change
+      uses: EndBug/add-and-commit@v9.1.1
+      with:
+        author_name: AlephZero Automation
+        author_email: alephzero@10clouds.com
+        # yamllint disable-line rule:line-length
+        message: "Upsert featurenet ${{ steps.get-argocd-featurnet-app-name.outputs.name }} with image: ${{ inputs.featurenet-aleph-node-image != '' && inputs.featurenet-aleph-node-image || steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
+        add: '["*.yaml","*.expiration.txt"]'
+        cwd: "${{ inputs.repo-featurenets-name }}"
+
+    - name: Refresh Argo and wait for the creation to be finished
+      shell: bash
+      run: |
+        cd "${{ inputs.repo-featurenets-name }}"
+        ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
+          "${{ inputs.argo-sync-user-token }}" \
+          "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -140,7 +140,7 @@ runs:
       if: ${{ inputs.featurenet-aleph-node-image == 'testnet' ||
         inputs.featurenet-aleph-node-image == 'mainnet' }}
       id: get-node-commit-sha
-      uses: Cardinal-Cryptography/github-actions/get-node-system-version@v1
+      uses: Cardinal-Cryptography/github-actions/get-node-system-version@A0-3204-add-featurenet-actions-from-aleph-node
       with:
         env: ${{ inputs.featurenet-aleph-node-image }}
 

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -2,9 +2,9 @@
 name: Create featurenet
 description: |
   This action several flows
-  * spawns new feature net bootstraped from PR, node binary is test one (short session)
+  * spawns new featurenet bootstraped from PR, node binary is test one (short session)
   * spawns new update net from a node image that is on ECR, prpduction one (normal session)
-  * upgrades feature net binary to a given version
+  * upgrades featurenet binary to a given version
 inputs:
   gh-ci-token:
     description: 'GH token to be used in the action'
@@ -25,12 +25,17 @@ inputs:
     description: 'S3 bucket name with featurenet keys'
     required: true
   featurenet-name:
-    description: 'Enter name instead of getting it from branch'
-    required: false
-    default: ''
+    description: 'Name of featurenet'
+    required: true
+  git-commit-author:
+    description: 'Git commit author when pushing to featurenets repository'
+    required: true
+  git-commit-email:
+    description: 'Git commit email when pushing to featurenets repository'
+    required: true
   featurenet-aleph-node-image:
     description: |
-      Set feature net image either to:
+      Set featurenet image either to:
        * 'testnet' or 'mainnet' - to Testnet or Mainnet image respectively,
        * a 7 byte SHA - to exisiting ECR aleph-node image tag
        * empty value - to image built from PR
@@ -42,7 +47,7 @@ inputs:
     default: ''
   rolling-update-partition:
     description: |
-      Number from 0 to N-1, where N is size of am existing feature net.
+      Number from 0 to N-1, where N is size of am existing featurenet.
       All aleph-node-validator-N with an ordinal N that is great than or equal to the partition
       will be updated. If not specified, all nodes will be updated.
     required: false
@@ -52,15 +57,18 @@ inputs:
       Number of pods to start, from 0 to 50.
     required: false
     default: "5"
-  append-run-id-to-name:
-    description: |
-      When 'true' then run ID will be appended to featurenet name
-    required: false
-    default: "false"
   internal:
     description: 'Internal network, accessible from VPN only'
     required: false
     default: "false"
+  hard-refresh:
+    description: 'Make hard-refresh of ArgoCD application'
+    required: false
+    default: "false"
+outputs:
+  ws-hostname:
+    description: Hostname of the WS endpoint
+    value: ${{ steps.start-featurenet.outputs.ws-hostname }}
 
 runs:
   using: "composite"
@@ -69,11 +77,10 @@ runs:
       shell: bash
       run: |
         if [[
-          "${{ inputs.featurenet-name }}" != "" && \
-          ! "${{ inputs.featurenet-name }}" =~ ^[a-z0-9][a-z0-9\-]{4,30}$
+          ! "${{ inputs.featurenet-name }}" =~ ^[a-z0-9][a-z0-9\-]{4,48}$
         ]]
         then
-          echo "!!! Invalid feature net name"
+          echo "!!! Invalid featurenet name"
           exit 1
         fi
         if [[
@@ -83,7 +90,7 @@ runs:
           "${{ inputs.featurenet-aleph-node-image }}" != "mainnet"
         ]]
         then
-          echo "!!! Invalid feature net node image tag"
+          echo "!!! Invalid featurenet node image tag"
           exit 1
         fi
         if [[
@@ -124,30 +131,17 @@ runs:
         path: "${{ inputs.repo-featurenets-name }}"
         ref: main
 
-    - name: Get argocd featurenet app name
-      id: get-argocd-featurnet-app-name
-      shell: bash
-      # yamllint disable rule:line-length
-      env:
-        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
-        APP_NAME_WITH_RUN_ID: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}-{2}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo, github.run_id) }}
-      run: |
-        name_local=${{ inputs.append-run-id-to-name == 'true' && env.APP_NAME_WITH_RUN_ID || env.APP_NAME }}
-        echo "name=$name_local" >> $GITHUB_OUTPUT
-      # yamllint enable rule:line-length
-
     - name: Get node commit SHA
       if: ${{ inputs.featurenet-aleph-node-image == 'testnet' ||
         inputs.featurenet-aleph-node-image == 'mainnet' }}
       id: get-node-commit-sha
-      uses: Cardinal-Cryptography/github-actions/get-node-system-version@A0-3204-add-featurenet-actions-from-aleph-node
+      uses: Cardinal-Cryptography/github-actions/get-node-system-version@v1
       with:
         env: ${{ inputs.featurenet-aleph-node-image }}
 
     - name: Start featurenet from PR branch
+      id: start-featurenet
       shell: bash
-      env:
-        OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-featurenets-name }}"
       # yamllint disable rule:line-length
       run: |
         cd "${{ inputs.repo-featurenets-name }}"
@@ -172,33 +166,34 @@ runs:
           fnet_create_hook="false"
         fi
         ./Ops.sh create-featurenet-using-kustomize \
-          "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \
+          "${{ inputs.featurenet-name }}" \
           "${fnet_aleph_node_image}" \
           "${fnet_bootstrap_chain_node_image}" \
           "${{ inputs.rolling-update-partition }}" \
           "${fnet_create_hook}" \
           "${{ inputs.replicas }}" \
-          "${{ inputs.internal == 'true' && 'true' || 'false' }}"
+          "${{ inputs.internal == 'true' && 'true' || 'false' }}" | tee -a tmp-opssh-createfeaturenet-output.txt
+
+        ws_hostname=$(cat tmp-opssh-createfeaturenet-output.txt | grep "^__output:ws-hostname:" | cut -d: -f3)
+        echo "ws-hostname=${ws_hostname}" >> $GITHUB_OUTPUT
       # yamllint enable rule:line-length
 
     - name: Set featurenet expiration
       if: inputs.expiration != ''
       shell: bash
-      env:
-        OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-featurenets-name }}"
       run: |
         cd "${{ inputs.repo-featurenets-name }}"
         ./Ops.sh create-featurenet-expiration \
-          "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \
+          "${{ inputs.featurenet-name }}" \
           "${{ inputs.expiration }}"
 
     - name: Commit featurenet change
       uses: EndBug/add-and-commit@v9.1.1
       with:
-        author_name: AlephZero Automation
-        author_email: alephzero@10clouds.com
+        author_name: "${{ inputs.git-commit-author }}"
+        author_email: "${{ inputs.git-commit-email }}"
         # yamllint disable-line rule:line-length
-        message: "Upsert featurenet ${{ steps.get-argocd-featurnet-app-name.outputs.name }} with image: ${{ inputs.featurenet-aleph-node-image != '' && inputs.featurenet-aleph-node-image || steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
+        message: "Upsert featurenet ${{ inputs.featurenet-name }} with image: ${{ inputs.featurenet-aleph-node-image != '' && inputs.featurenet-aleph-node-image || steps.get-ref-properties.outputs.branch-name-for-argo-with-sha }}"
         add: '["*.yaml","*.expiration.txt"]'
         cwd: "${{ inputs.repo-featurenets-name }}"
 
@@ -208,4 +203,5 @@ runs:
         cd "${{ inputs.repo-featurenets-name }}"
         ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
           "${{ inputs.argo-sync-user-token }}" \
-          "${{ steps.get-argocd-featurnet-app-name.outputs.name }}" \
+          "${{ inputs.featurenet-name }}" \
+          "${{ inputs.hard-refresh == 'true' && 'true' || 'false' }}"

--- a/delete-featurenet/action.yml
+++ b/delete-featurenet/action.yml
@@ -28,14 +28,14 @@ inputs:
     description: 'ArgoCD user token to be used in the action'
     required: true
   featurenet-name:
-    description: 'Enter name instead of getting it from branch'
-    required: false
-    default: ''
-  append-run-id-to-name:
-    description: |
-      When 'true' then run ID will be appended to featurenet name
-    required: false
-    default: "false"
+    description: 'Name of featurenet'
+    required: true
+  git-commit-author:
+    description: 'Git commit author when pushing to featurenets repository'
+    required: true
+  git-commit-email:
+    description: 'Git commit email when pushing to featurenets repository'
+    required: true
 
 runs:
   using: "composite"
@@ -44,18 +44,21 @@ runs:
       shell: bash
       run: |
         if [[
-          "${{ inputs.featurenet-name }}" != "" && \
-          ! "${{ inputs.featurenet-name }}" =~ ^[a-z0-9][a-z0-9\-]{4,30}$
+          ! "${{ inputs.featurenet-name }}" =~ ^[a-z0-9][a-z0-9\-]{4,48}$
         ]]
         then
           echo "!!! Invalid feature net name"
           exit 1
         fi
 
-    - name: Get branch name and commit SHA
-      id: get-ref-properties
-      # yamllint disable-line rule:line-length
-      uses: Cardinal-Cryptography/github-actions/get-ref-properties@v1
+    - name: Get final featurenet name
+      id: get-final-name
+      shell: bash
+      # yamllint disable rule:line-length
+      run: |
+        final_name_local=${{ inputs.featurenet-name }}
+        echo "final-featurenet-name=$final_name_local" >> $GITHUB_OUTPUT
+      # yamllint enable rule:line-length
 
     - name: Checkout featurenets repo
       uses: actions/checkout@v3
@@ -74,33 +77,19 @@ runs:
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
         aws-region: ${{ env.AWS_REGION }}
 
-    - name: Get argocd featurenet app name
-      id: get-argocd-featurnet-app-name
-      shell: bash
-      # yamllint disable rule:line-length
-      env:
-        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
-        APP_NAME_WITH_RUN_ID: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}-{2}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo, github.run_id) }}
-      run: |
-        name_local=${{ inputs.append-run-id-to-name == 'true' && env.APP_NAME_WITH_RUN_ID || env.APP_NAME }}
-        echo "name=$name_local" >> $GITHUB_OUTPUT
-      # yamllint enable rule:line-length
-
     - name: Destroy feature branch
       shell: bash
-      env:
-        OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-featurenets-name }}"
       run: |
         cd "${{ inputs.repo-featurenets-name }}"
-        ./Ops.sh delete-featurenet "${{ steps.get-argocd-featurnet-app-name.outputs.name }}"
+        ./Ops.sh delete-featurenet "${{ steps.get-final-name.outputs.final-featurenet-name }}"
       # yamllint enable rule:line-length
 
     - name: Commit deletion of the feature environment.
       uses: EndBug/add-and-commit@v9.1.1
       with:
-        author_name: AlephZero Automation
-        author_email: alephzero@10clouds.com
-        message: "Delete featurenet ${{ steps.get-argocd-featurnet-app-name.outputs.name }}"
+        author_name: "${{ inputs.git-commit-author }}"
+        author_email: "${{ inputs.git-commit-email }}"
+        message: "Delete featurenet ${{ steps.get-final-name.outputs.final-featurenet-name }}"
         add: '["*.yaml","*.expiration.txt"]'
         cwd: "${{ inputs.repo-featurenets-name }}"
 
@@ -120,6 +109,6 @@ runs:
           -e AWS_SECRET_ACCESS_KEY \
           -e AWS_REGION \
           -e FEATURENETS_S3_BUCKET_NAME=${{ inputs.featurenet-keys-s3bucket-name }} \
-          -e FEATURENET_NAME=${{ steps.get-argocd-featurnet-app-name.outputs.name }} \
-          ${{ inputs.ecr-public-registry }}featurenet-helper:v0.3.0 \
+          -e FEATURENET_NAME=${{ steps.get-final-name.outputs.final-featurenet-name }} \
+          ${{ inputs.ecr-public-registry }}featurenet-helper:v0.4.0 \
           delete-featurenet-data-from-s3

--- a/delete-featurenet/action.yml
+++ b/delete-featurenet/action.yml
@@ -109,6 +109,6 @@ runs:
           -e AWS_SECRET_ACCESS_KEY \
           -e AWS_REGION \
           -e FEATURENETS_S3_BUCKET_NAME=${{ inputs.featurenet-keys-s3bucket-name }} \
-          -e FEATURENET_NAME=${{ steps.get-final-name.outputs.final-featurenet-name }} \
+          -e FEATURENET_NAME=fe-${{ steps.get-final-name.outputs.final-featurenet-name }} \
           ${{ inputs.ecr-public-registry }}featurenet-helper:v0.4.0 \
           delete-featurenet-data-from-s3

--- a/delete-featurenet/action.yml
+++ b/delete-featurenet/action.yml
@@ -1,0 +1,125 @@
+---
+name: Delete featurenet
+description: Deletes featurenet
+
+inputs:
+  gh-ci-token:
+    description: 'GH token to be used in the action'
+    required: true
+  repo-featurenets-name:
+    description: 'Name of the repository containing featurenets manifests'
+    required: true
+  aws-access-key-id:
+    description: 'AWS Access Key ID to be used in the action'
+    required: true
+  aws-secret-access-key:
+    description: 'AWS Secret Access Key to be used in the action'
+    required: true
+  ecr-public-registry:
+    description: "ECR public registry, with slash at the end, eg. 'public.ecr.aws/something/'"
+    required: true
+  featurenet-keys-s3bucket-name:
+    description: 'S3 bucket name with featurenet keys'
+    required: true
+  argo-host:
+    description: 'ArgoCD host'
+    required: true
+  argo-sync-user-token:
+    description: 'ArgoCD user token to be used in the action'
+    required: true
+  featurenet-name:
+    description: 'Enter name instead of getting it from branch'
+    required: false
+    default: ''
+  append-run-id-to-name:
+    description: |
+      When 'true' then run ID will be appended to featurenet name
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate inputs
+      shell: bash
+      run: |
+        if [[
+          "${{ inputs.featurenet-name }}" != "" && \
+          ! "${{ inputs.featurenet-name }}" =~ ^[a-z0-9][a-z0-9\-]{4,30}$
+        ]]
+        then
+          echo "!!! Invalid feature net name"
+          exit 1
+        fi
+
+    - name: Get branch name and commit SHA
+      id: get-ref-properties
+      # yamllint disable-line rule:line-length
+      uses: Cardinal-Cryptography/github-actions/get-ref-properties@v1
+
+    - name: Checkout featurenets repo
+      uses: actions/checkout@v3
+      with:
+        repository: Cardinal-Cryptography/${{ inputs.repo-featurenets-name }}
+        token: ${{ inputs.gh-ci-token }}
+        path: "${{ inputs.repo-featurenets-name }}"
+        ref: main
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      env:
+        AWS_REGION: us-east-1
+      with:
+        aws-access-key-id: ${{ inputs.aws-access-key-id }}
+        aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
+        aws-region: ${{ env.AWS_REGION }}
+
+    - name: Get argocd featurenet app name
+      id: get-argocd-featurnet-app-name
+      shell: bash
+      # yamllint disable rule:line-length
+      env:
+        APP_NAME: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo) }}
+        APP_NAME_WITH_RUN_ID: ${{ inputs.featurenet-name != '' && inputs.featurenet-name || format('{0}{1}-{2}', 'fe-', steps.get-ref-properties.outputs.branch-name-for-argo, github.run_id) }}
+      run: |
+        name_local=${{ inputs.append-run-id-to-name == 'true' && env.APP_NAME_WITH_RUN_ID || env.APP_NAME }}
+        echo "name=$name_local" >> $GITHUB_OUTPUT
+      # yamllint enable rule:line-length
+
+    - name: Destroy feature branch
+      shell: bash
+      env:
+        OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-featurenets-name }}"
+      run: |
+        cd "${{ inputs.repo-featurenets-name }}"
+        ./Ops.sh delete-featurenet "${{ steps.get-argocd-featurnet-app-name.outputs.name }}"
+      # yamllint enable rule:line-length
+
+    - name: Commit deletion of the feature environment.
+      uses: EndBug/add-and-commit@v9.1.1
+      with:
+        author_name: AlephZero Automation
+        author_email: alephzero@10clouds.com
+        message: "Delete featurenet ${{ steps.get-argocd-featurnet-app-name.outputs.name }}"
+        add: '["*.yaml","*.expiration.txt"]'
+        cwd: "${{ inputs.repo-featurenets-name }}"
+
+    # we need self-hosted runner only because of this step
+    - name: Refresh Argo and wait for the deletion to be finished
+      shell: bash
+      run: |
+        cd "${{ inputs.repo-featurenets-name }}"
+        ./Ops.sh refresh-featurenets "${{ inputs.argo-host }}" \
+          "${{ inputs.argo-sync-user-token }}"
+
+    - name: Clean S3 storage
+      shell: bash
+      run: |
+        docker run --rm \
+          -e AWS_ACCESS_KEY_ID \
+          -e AWS_SECRET_ACCESS_KEY \
+          -e AWS_REGION \
+          -e FEATURENETS_S3_BUCKET_NAME=${{ inputs.featurenet-keys-s3bucket-name }} \
+          -e FEATURENET_NAME=${{ steps.get-argocd-featurnet-app-name.outputs.name }} \
+          ${{ inputs.ecr-public-registry }}featurenet-helper:v0.3.0 \
+          delete-featurenet-data-from-s3

--- a/get-node-system-version/action.yml
+++ b/get-node-system-version/action.yml
@@ -1,0 +1,35 @@
+---
+name: Get aleph-node system version
+description: Queries Testnet or Mainnet RPC endpoint call system.version, and parses commit SHA
+  from the response
+inputs:
+  env:
+    required: true
+    description: mainnet or testnet
+outputs:
+  sha:
+    description: Commit SHA of RPC call system.version
+    value: ${{ steps.rpc-system-version.outputs.sha }}
+
+runs:
+  using: composite
+  steps:
+    - name: Validate action inputs
+      shell: bash
+      run: |
+        if [[ ${{ inputs.env }} != 'testnet' && ${{ inputs.env }} != 'mainnet' ]]; then
+          echo "Error: inputs.env should be either mainnet or testnet!"
+          exit 1
+        fi
+
+    - name: Query RPC system.version
+      id: rpc-system-version
+      shell: bash
+      # yamllint disable rule:line-length
+      run: |
+        COMMIT_ID=$(curl -s -H "Content-Type: application/json" \
+          -d '{"id":1, "jsonrpc":"2.0", "method": "system_version"}' \
+          "${{ inputs.env == 'mainnet' && 'https://rpc.azero.dev' || 'https://rpc.test.azero.dev' }}" \
+          | jq -r '.result' | cut -d "-" -f 2 | head -c 7)
+        echo "sha=$COMMIT_ID" >> $GITHUB_OUTPUT
+      # yamllint enable rule:line-length

--- a/wait-for-finalized-heads/action.yml
+++ b/wait-for-finalized-heads/action.yml
@@ -6,31 +6,31 @@ inputs:
   gh-ci-token:
     description: 'GH token to be used in the action'
     required: true
-  repo-apps-name:
-    description: 'Name of the repository containing apps definitions'
+  repo-featurenets-name:
+    description: 'Name of the repository containing featurenets definitions'
     required: true
   json-rpc-endpoint:
     description: 'JSON RPC endpoint, eg. https://dev.azero.dev'
     required: true
-  repo-apps-checkout:
-    description: "Checkout apps repository"
+  repo-featurenets-checkout:
+    description: "Checkout featurenets repository"
     required: false
     default: 'false'
 
 runs:
   using: "composite"
   steps:
-    - name: Checkout argocd apps repo
-      if: inputs.repo-apps-checkout == 'true'
+    - name: Checkout argocd featurenets repo
+      if: inputs.repo-featurenets-checkout == 'true'
       uses: actions/checkout@v3
       with:
-        repository: Cardinal-Cryptography/${{ inputs.repo-apps-name }}
+        repository: Cardinal-Cryptography/${{ inputs.repo-featurenets-name }}
         token: ${{ inputs.gh-ci-token }}
-        path: "${{ inputs.repo-apps-name }}"
+        path: "${{ inputs.repo-featurenets-name }}"
         ref: main
 
     - name: Wait for the unique consecutive finalized heads
       shell: bash
       run: |
-        cd "${{ inputs.repo-apps-name }}"
+        cd "${{ inputs.repo-featurenets-name }}"
         ./Ops.sh wait-for-finalized-heads "${{ inputs.json-rpc-endpoint }}"


### PR DESCRIPTION
## Description
Adds featurenet actions so they can be used in all of the repositories, not just aleph-node.

Featurenet actions already have the additional `internal` input which is part of the following PR: https://github.com/Cardinal-Cryptography/aleph-node/pull/1391 

### pre-merge steps
Change ref in the following line to `v1`:
````
Cardinal-Cryptography/github-actions/get-node-system-version@A0-3204-add-featurenet-actions-from-aleph-node
````

### post-merge steps
Make new tags.