### PR TITLE
A0-3296: Make create-branchpreview returns all outputs encoded with base64

### DIFF
--- a/.github/workflows/_branchpreview-create.yml
+++ b/.github/workflows/_branchpreview-create.yml
@@ -20,6 +20,10 @@ on:
         description: "Choose from 'private' or 'public'"
         required: true
         type: string
+    outputs:
+      base64:
+        description: Outputs encoded with base64
+        value: ${{ jobs.create-branchpreview.outputs.base64 }}
 
 jobs:
   check-vars-and-secrets:
@@ -31,9 +35,12 @@ jobs:
     needs: [check-vars-and-secrets]
     name: Create branchpreview
     runs-on: [self-hosted, Linux, X64, small]
+    outputs:
+      base64: ${{ steps.create-branchpreview.outputs.base64 }}
     steps:
       - name: Create branchpreview
-        uses: Cardinal-Cryptography/github-actions/create-branchpreview@v3
+        id: create-branchpreview
+        uses: Cardinal-Cryptography/github-actions/create-branchpreview@A0-3296-make-branchpreview-create-return-all-outputs
         with:
           repository-name: ${{ inputs.repository-name }}
           branch-name: ${{ inputs.branch-name }}
@@ -46,4 +53,4 @@ jobs:
           argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
           git-commit-author: ${{ secrets.AUTOCOMMIT_AUTHOR }}
           git-commit-email: ${{ secrets.AUTOCOMMIT_EMAIL }}
-          hard-refresh: "true"
+          hard-refresh: 'true'

--- a/.github/workflows/_branchpreview-create.yml
+++ b/.github/workflows/_branchpreview-create.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: Create branchpreview
         id: create-branchpreview
-        uses: Cardinal-Cryptography/github-actions/create-branchpreview@A0-3296-make-branchpreview-create-return-all-outputs
+        uses: Cardinal-Cryptography/github-actions/create-branchpreview@v3
         with:
           repository-name: ${{ inputs.repository-name }}
           branch-name: ${{ inputs.branch-name }}

--- a/.github/workflows/_check-vars-and-secrets.yml
+++ b/.github/workflows/_check-vars-and-secrets.yml
@@ -13,36 +13,36 @@ jobs:
       - name: Check vars
         run: |
           if [[ \
-            -z "${{ vars.ECR_PUBLIC_HOST }}" || \
-            -z "${{ vars.ECR_PUBLIC_REGISTRY }}" || \
-            -z "${{ vars.ECR_ALEPH_NODE_REPO }}" || \
-            -z "${{ vars.KUSTOMIZE_VERSION }}"
+            -z '${{ vars.ECR_PUBLIC_HOST }}' || \
+            -z '${{ vars.ECR_PUBLIC_REGISTRY }}' || \
+            -z '${{ vars.ECR_ALEPH_NODE_REPO }}' || \
+            -z '${{ vars.KUSTOMIZE_VERSION }}'
           ]]; then
-            echo "!!! Some repository variables are either missing or empty."
-            echo "!!! Please check either repository or organization settings."
+            echo '!!! Some repository variables are either missing or empty.'
+            echo '!!! Please check either repository or organization settings.'
             exit 1
           fi
 
       - name: Check secrets
         run: |
           if [[ \
-            -z "${{ secrets.ARGOCD_DEVNET_HOST }}" || \
-            -z "${{ secrets.ARGO_SYNC_USER_TOKEN }}" || \
-            -z "${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}" || \
-            -z "${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}" || \
-            -z "${{ secrets.AUTOCOMMIT_AUTHOR }}" || \
-            -z "${{ secrets.AUTOCOMMIT_EMAIL }}" || \
-            -z "${{ secrets.CI_DEVNET_S3BUCKET_NAME }}" || \
-            -z "${{ secrets.CI_GH_TOKEN }}" || \
-            -z "${{ secrets.DEVNET_KEYS_S3BUCKET_NAME }}" || \
-            -z "${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}" || \
-            -z "${{ secrets.REPO_ARGOCD_APPS_NAME }}" || \
-            -z "${{ secrets.REPO_OPS_FEATURENETS_NAME }}" || \
-            -z "${{ secrets.REPO_FEATURENET_TEMPLATE_NAME }}" || \
-            -z "${{ secrets.REPO_BRANCHPREVIEW_TEMPLATES_NAME }}" || \
-            -z "${{ secrets.REPO_OPS_BRANCHPREVIEWS_NAME }}"
+            -z '${{ secrets.ARGOCD_DEVNET_HOST }}' || \
+            -z '${{ secrets.ARGO_SYNC_USER_TOKEN }}' || \
+            -z '${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}' || \
+            -z '${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}' || \
+            -z '${{ secrets.AUTOCOMMIT_AUTHOR }}' || \
+            -z '${{ secrets.AUTOCOMMIT_EMAIL }}' || \
+            -z '${{ secrets.CI_DEVNET_S3BUCKET_NAME }}' || \
+            -z '${{ secrets.CI_GH_TOKEN }}' || \
+            -z '${{ secrets.DEVNET_KEYS_S3BUCKET_NAME }}' || \
+            -z '${{ secrets.FEATURENET_KEYS_S3BUCKET_NAME }}' || \
+            -z '${{ secrets.REPO_ARGOCD_APPS_NAME }}' || \
+            -z '${{ secrets.REPO_OPS_FEATURENETS_NAME }}' || \
+            -z '${{ secrets.REPO_FEATURENET_TEMPLATE_NAME }}' || \
+            -z '${{ secrets.REPO_BRANCHPREVIEW_TEMPLATES_NAME }}' || \
+            -z '${{ secrets.REPO_OPS_BRANCHPREVIEWS_NAME }}'
           ]]; then
-            echo "!!! Some repository secrets are either missing or empty."
-            echo "!!! Please check either repository or organization settings."
+            echo '!!! Some repository secrets are either missing or empty.'
+            echo '!!! Please check either repository or organization settings.'
             exit 1
           fi

--- a/.github/workflows/_featurenet-create-from-branch.yml
+++ b/.github/workflows/_featurenet-create-from-branch.yml
@@ -34,10 +34,10 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           if [[
-          ! "${{ inputs.featurenet-name }}" =~ ^[a-z0-9][a-z0-9\-]{4,48}$
+          ! '${{ inputs.featurenet-name }}' =~ ^[a-z0-9][a-z0-9\-]{4,48}$
           ]]
           then
-            echo "!!! Invalid featurenet name"
+            echo '!!! Invalid featurenet name'
             exit 1
           fi
         # yamllint enable rule:line-length

--- a/.github/workflows/_featurenet-create-from-net.yml
+++ b/.github/workflows/_featurenet-create-from-net.yml
@@ -38,10 +38,10 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           if [[
-          ! "${{ inputs.featurenet-name }}" =~ ^[a-z0-9][a-z0-9\-]{4,48}$
+          ! '${{ inputs.featurenet-name }}' =~ ^[a-z0-9][a-z0-9\-]{4,48}$
           ]]
           then
-            echo "!!! Invalid featurenet name"
+            echo '!!! Invalid featurenet name'
             exit 1
           fi
         # yamllint enable rule:line-length

--- a/.github/workflows/_featurenet-delete.yml
+++ b/.github/workflows/_featurenet-delete.yml
@@ -19,10 +19,10 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           if [[
-          ! "${{ inputs.featurenet-name }}" =~ ^[a-z0-9][a-z0-9\-]{4,48}$
+          ! '${{ inputs.featurenet-name }}' =~ ^[a-z0-9][a-z0-9\-]{4,48}$
           ]]
           then
-            echo "!!! Invalid featurenet name"
+            echo '!!! Invalid featurenet name'
             exit 1
           fi
         # yamllint enable rule:line-length

--- a/.github/workflows/_featurenet-update.yml
+++ b/.github/workflows/_featurenet-update.yml
@@ -41,10 +41,10 @@ jobs:
         # yamllint disable rule:line-length
         run: |
           if [[
-          ! "${{ inputs.featurenet-name }}" =~ ^[a-z0-9][a-z0-9\-]{4,48}$
+          ! '${{ inputs.featurenet-name }}' =~ ^[a-z0-9][a-z0-9\-]{4,48}$
           ]]
           then
-            echo "!!! Invalid featurenet name"
+            echo '!!! Invalid featurenet name'
             exit 1
           fi
         # yamllint enable rule:line-length

--- a/check-pr-title/action.yml
+++ b/check-pr-title/action.yml
@@ -18,14 +18,14 @@ runs:
         PR_TITLE: ${{ inputs.pr-title }}
       run: |
         #!/bin/bash
-        if [[ -n "$PR_TITLE" ]]; then
-          if ! echo "$PR_TITLE" | grep -Eq "^A0-[0-9]+: .*$"; then
+        if [[ -n '${{ env.PR_TITLE }}' ]]; then
+          if ! echo '${{ env.PR_TITLE }}' | grep -Eq "^A0-[0-9]+: .*$"; then
             echo -e "The PR title is wrong \n \
             Please follow this pattern:\nA0-[ticket-number]: Short description\n\
             Example: \"A0-1337: Add h4x0r l33t code\""
             exit 1
           fi
-          if echo "$PR_TITLE" | grep -Eq "^A0-0000.*$"; then
+          if echo '${{ env.PR_TITLE }}' | grep -Eq "^A0-0000.*$"; then
             echo "A0-0000 ticket number cannot be used in the PR title"
             exit 1
           fi

--- a/copy-file-to-s3/action.yml
+++ b/copy-file-to-s3/action.yml
@@ -29,16 +29,16 @@ runs:
       shell: bash
       run: |
         if [[
-          "${{ inputs.compression }}" == "true" && \
-          "${{ inputs.source-filename }}" == "${{ inputs.s3-bucket-filename }}"
+          '${{ inputs.compression }}' == 'true' && \
+          '${{ inputs.source-filename }}' == '${{ inputs.s3-bucket-filename }}'
         ]]; then
           echo "!!! When compression is 'true', source file cannot have the same"
           echo "!!! name as compressed file uploaded to S3 bucket."
           exit 1
         fi
         if [[
-          "${{ inputs.compression }}" == "true" && \
-          "${{ inputs.source-filename }}" =~ ^.*\.(tar\.gz|tgz)$
+          '${{ inputs.compression }}' == 'true' && \
+          '${{ inputs.source-filename }}' =~ ^.*\.(tar\.gz|tgz)$
         ]]; then
           echo "! "
           echo "! Source file has .tar.gz or .tgz extension so it seems to be compressed already."
@@ -47,8 +47,8 @@ runs:
           echo "! "
         fi
         if [[
-          "${{ inputs.compression }}" == "true" && \
-          ! "${{ inputs.s3-bucket-filename }}" =~ ^.*\.(tar\.gz|tgz)$
+          '${{ inputs.compression }}' == 'true' && \
+          ! '${{ inputs.s3-bucket-filename }}' =~ ^.*\.(tar\.gz|tgz)$
         ]]; then
           echo "! "
           echo "! File is going to be compressed but its file extension will not be"
@@ -56,9 +56,9 @@ runs:
           echo "! "
         fi
         if [[
-          "${{ inputs.compression }}" == "false" && \
-          ! "${{ inputs.source-filename }}" =~ ^.*\.(tar\.gz|tgz)$ && \
-          "${{ inputs.s3-bucket-filename }}" =~ ^.*\.(tar\.gz|tgz)$
+          '${{ inputs.compression }}' == 'false' && \
+          ! '${{ inputs.source-filename }}' =~ ^.*\.(tar\.gz|tgz)$ && \
+          '${{ inputs.s3-bucket-filename }}' =~ ^.*\.(tar\.gz|tgz)$
         ]]; then
           echo "! "
           echo "! File is not going to be compressed but its file extension suggests"
@@ -71,16 +71,16 @@ runs:
           --key '${{ inputs.s3-bucket-path }}/${{ inputs.s3-bucket-filename }}' \
           2> /dev/null || not_exist=true
         if [[ "${not_exist}" ]]; then
-          target_s3_filepath=${{ inputs.s3-bucket-path }}/${{ inputs.s3-bucket-filename }}
-          if [[ "${{ inputs.compression}}" == "true" ]]; then
-            tar -cvzf ${{ inputs.s3-bucket-filename }} -C ${{ inputs.source-path }} \
-              ${{ inputs.source-filename }}
-            aws s3 cp ${{ inputs.s3-bucket-filename }} \
+          target_s3_filepath='${{ inputs.s3-bucket-path }}/${{ inputs.s3-bucket-filename }}'
+          if [[ '${{ inputs.compression}}' == 'true' ]]; then
+            tar -cvzf '${{ inputs.s3-bucket-filename }}' -C '${{ inputs.source-path }}' \
+              '${{ inputs.source-filename }}'
+            aws s3 cp '${{ inputs.s3-bucket-filename }}' \
               s3://${{ inputs.s3-bucket-name }}/"${target_s3_filepath}"
           else
-            aws s3 cp ${{ inputs.source-path }} \
+            aws s3 cp '${{ inputs.source-path }}' \
               s3://${{ inputs.s3-bucket-name }}/"${target_s3_filepath}"
           fi
         else
-          echo "File ${{ inputs.s3-bucket-filename }} already exists on S3 bucket."
+          echo 'File ${{ inputs.s3-bucket-filename }} already exists on S3 bucket.'
         fi

--- a/create-branchpreview/action.yml
+++ b/create-branchpreview/action.yml
@@ -45,7 +45,9 @@ outputs:
   safe-branch-name:
     description: Safe branch name
     value: ${{ steps.start-branchpreview.outputs.safe-branch-name }}
-
+  base64:
+    description: All outputs encoded in base64
+    value: ${{ steps.start-branchpreview.outputs.all-base64 }}
 runs:
   using: "composite"
   steps:
@@ -53,18 +55,18 @@ runs:
       shell: bash
       run: |
         if [[
-          ! "${{ inputs.repository-name }}" =~ ^[a-zA-Z0-9-]+$
+          ! '${{ inputs.repository-name }}' =~ ^[a-zA-Z0-9-]+$
         ]]
         then
-          echo "!!! Invalid repository name"
+          echo '!!! Invalid repository name'
           exit 1
         fi
 
         if [[
-          ! "${{ inputs.branch-name }}" =~ ^[a-zA-Z0-9/_-]+$
+          ! '${{ inputs.branch-name }}' =~ ^[a-zA-Z0-9/_-]+$
         ]]
         then
-          echo "!!! Invalid branch name"
+          echo '!!! Invalid branch name'
           exit 1
         fi
 
@@ -73,7 +75,7 @@ runs:
       with:
         repository: Cardinal-Cryptography/${{ inputs.repo-branchpreviews-name }}
         token: ${{ inputs.gh-ci-token }}
-        path: "${{ inputs.repo-branchpreviews-name }}"
+        path: '${{ inputs.repo-branchpreviews-name }}'
         ref: main
 
     - name: Checkout branchpreview templates repo
@@ -81,7 +83,7 @@ runs:
       with:
         repository: Cardinal-Cryptography/${{ inputs.repo-branchpreview-templates-name }}
         token: ${{ inputs.gh-ci-token }}
-        path: "${{ inputs.repo-branchpreview-templates-name }}"
+        path: '${{ inputs.repo-branchpreview-templates-name }}'
         ref: compatibility
 
     - name: Start branchpreview
@@ -91,37 +93,40 @@ runs:
       env:
         OPSSH_TARGETPATH: ${{ github.workspace }}/${{ inputs.repo-branchpreviews-name }}
       run: |
-        cd "${{ inputs.repo-branchpreview-templates-name }}"
+        cd '${{ inputs.repo-branchpreview-templates-name }}'
         ./Ops.sh create-branchpreview \
-          "${{ inputs.repository-name }}" \
-          "${{ inputs.branch-name }}" \
-          "${{ inputs.image }}" | tee -a tmp-opssh-createbranchpreviews-output.txt
+          '${{ inputs.repository-name }}' \
+          '${{ inputs.branch-name }}' \
+          '${{ inputs.image }}' | tee -a tmp-opssh-createbranchpreviews-output.txt
 
-        app_name=$(cat tmp-opssh-createbranchpreviews-output.txt | grep "^__output:app-name:" | cut -d: -f3)
-        safe_branch_name=$(cat tmp-opssh-createbranchpreviews-output.txt | grep "^__output:safe-branch-name:" | cut -d: -f3)
-        image_tag=$(echo "${{ inputs.image }}" | cut -d: -f2)
+        app_name=$(cat tmp-opssh-createbranchpreviews-output.txt | grep '^__output:app-name:' | cut -d: -f3)
+        safe_branch_name=$(cat tmp-opssh-createbranchpreviews-output.txt | grep '^__output:safe-branch-name:' | cut -d: -f3)
+        image_tag=$(echo '${{ inputs.image }}' | cut -d: -f2)
+        all_base64=$(cat tmp-opssh-createbranchpreviews-output.txt | grep '^__output:' | sed 's|__output:||g' | base64 -w 0)
+
         echo "app-name=${app_name}" >> $GITHUB_OUTPUT
         echo "safe-branch-name=${safe_branch_name}" >> $GITHUB_OUTPUT
         echo "image-tag=${image_tag}" >> $GITHUB_OUTPUT
+        echo "all-base64=${all_base64}" >> $GITHUB_OUTPUT
       # yamllint enable rule:line-length
 
     - name: Commit branchpreview change
       uses: EndBug/add-and-commit@v9.1.1
       with:
-        author_name: "${{ inputs.git-commit-author }}"
-        author_email: "${{ inputs.git-commit-email }}"
+        author_name: '${{ inputs.git-commit-author }}'
+        author_email: '${{ inputs.git-commit-email }}'
         # yamllint disable-line rule:line-length
-        message: "Upsert ${{ inputs.repository-name }}:${{ inputs.branch-name }} with image tag: ${{ steps.start-branchpreview.outputs.image-tag }}"
+        message: 'Upsert ${{ inputs.repository-name }}:${{ inputs.branch-name }} with image tag: ${{ steps.start-branchpreview.outputs.image-tag }}'
         add: '["*.yaml","*.txt"]'
-        cwd: "${{ inputs.repo-branchpreviews-name }}"
+        cwd: '${{ inputs.repo-branchpreviews-name }}'
 
     - name: Refresh Argo and wait for the creation to be finished
       shell: bash
       env:
-        OPSSH_TARGETPATH: "${{ github.workspace }}/${{ inputs.repo-branchpreviews-name }}"
+        OPSSH_TARGETPATH: '${{ github.workspace }}/${{ inputs.repo-branchpreviews-name }}'
       run: |
-        cd "${{ inputs.repo-branchpreview-templates-name }}"
-        ./Ops.sh refresh-branchpreviews "${{ inputs.argo-host }}" \
-          "${{ inputs.argo-sync-user-token }}" \
-          "${{ steps.start-branchpreview.outputs.app-name }}" \
-          "${{ inputs.hard-refresh == 'true' && 'true' || 'false' }}"
+        cd '${{ inputs.repo-branchpreview-templates-name }}'
+        ./Ops.sh refresh-branchpreviews '${{ inputs.argo-host }}' \
+          '${{ inputs.argo-sync-user-token }}' \
+          '${{ steps.start-branchpreview.outputs.app-name }}' \
+          '${{ inputs.hard-refresh == 'true' && 'true' || 'false' }}'

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -84,42 +84,42 @@ runs:
       shell: bash
       run: |
         if [[
-          ! "${{ inputs.featurenet-name }}" =~ ^[a-z0-9][a-z0-9\-]{4,48}$
+          ! '${{ inputs.featurenet-name }}' =~ ^[a-z0-9][a-z0-9\-]{4,48}$
         ]]
         then
           echo "!!! Invalid featurenet name"
           exit 1
         fi
         if [[
-          "${{ inputs.featurenet-aleph-node-image }}" != "" && \
-          ! "${{ inputs.featurenet-aleph-node-image }}" =~ ^[a-f0-9]{7}$ && \
-          "${{ inputs.featurenet-aleph-node-image }}" != "testnet" && \
-          "${{ inputs.featurenet-aleph-node-image }}" != "mainnet"
+          '${{ inputs.featurenet-aleph-node-image }}' != "" && \
+          ! '${{ inputs.featurenet-aleph-node-image }}' =~ ^[a-f0-9]{7}$ && \
+          '${{ inputs.featurenet-aleph-node-image }}' != "testnet" && \
+          '${{ inputs.featurenet-aleph-node-image }}' != "mainnet"
         ]]
         then
           echo "!!! Invalid featurenet node image tag"
           exit 1
         fi
         if [[
-          "${{ inputs.rolling-update-partition }}" != "" && \
-          ! "${{ inputs.rolling-update-partition }}" =~ ^[0-9]$
+          '${{ inputs.rolling-update-partition }}' != "" && \
+          ! '${{ inputs.rolling-update-partition }}' =~ ^[0-9]$
         ]]
         then
           echo "!!! Expected rolling update partition to be a cardinal value from 0 to 9"
           exit 1
         fi
         if [[
-          "${{ inputs.replicas }}" != "" && \
-          ! "${{ inputs.replicas }}" =~ ^[0-9]{1,2}$ || "${{ inputs.replicas }}" -gt 50
+          '${{ inputs.replicas }}' != "" && \
+          ! '${{ inputs.replicas }}' =~ ^[0-9]{1,2}$ || '${{ inputs.replicas }}' -gt 50
         ]]
         then
           echo "!!! Expected replicas to be a cardinal value from 0 to 50"
           exit 1
         fi
         if [[
-          "${{ inputs.expiration }}" != "" && \
-          ! "${{ inputs.expiration }}" =~ ^[0-9]{1,6}h$ && \
-          "${{ inputs.expiration }}" != "never"
+          '${{ inputs.expiration }}' != "" && \
+          ! '${{ inputs.expiration }}' =~ ^[0-9]{1,6}h$ && \
+          '${{ inputs.expiration }}' != "never"
         ]]
         then
           echo "!!! Expected expiration to have values from set {3h, 12h, 24h, 48h, 96h, never}"

--- a/delete-branchpreview/action.yml
+++ b/delete-branchpreview/action.yml
@@ -38,18 +38,18 @@ runs:
       shell: bash
       run: |
         if [[
-          ! "${{ inputs.repository-name }}" =~ ^[a-zA-Z0-9-]+$
+          ! '${{ inputs.repository-name }}' =~ ^[a-zA-Z0-9-]+$
         ]]
         then
-          echo "!!! Invalid repository name"
+          echo '!!! Invalid repository name'
           exit 1
         fi
 
         if [[
-          ! "${{ inputs.branch-name }}" =~ ^[a-zA-Z0-9/_-]+$
+          ! '${{ inputs.branch-name }}' =~ ^[a-zA-Z0-9/_-]+$
         ]]
         then
-          echo "!!! Invalid branch name"
+          echo '!!! Invalid branch name'
           exit 1
         fi
 
@@ -58,7 +58,7 @@ runs:
       with:
         repository: Cardinal-Cryptography/${{ inputs.repo-branchpreviews-name }}
         token: ${{ inputs.gh-ci-token }}
-        path: "${{ inputs.repo-branchpreviews-name }}"
+        path: '${{ inputs.repo-branchpreviews-name }}'
         ref: main
 
     - name: Checkout branchpreview templates repo
@@ -66,7 +66,7 @@ runs:
       with:
         repository: Cardinal-Cryptography/${{ inputs.repo-branchpreview-templates-name }}
         token: ${{ inputs.gh-ci-token }}
-        path: "${{ inputs.repo-branchpreview-templates-name }}"
+        path: '${{ inputs.repo-branchpreview-templates-name }}'
         ref: compatibility
 
     - name: Destroy branchpreview
@@ -74,19 +74,19 @@ runs:
       env:
         OPSSH_TARGETPATH: ${{ github.workspace }}/${{ inputs.repo-branchpreviews-name }}
       run: |
-        cd "${{ inputs.repo-branchpreview-templates-name }}"
+        cd '${{ inputs.repo-branchpreview-templates-name }}'
         ./Ops.sh delete-branchpreview \
-          "${{ inputs.repository-name }}" \
-          "${{ inputs.branch-name }}"
+          '${{ inputs.repository-name }}' \
+          '${{ inputs.branch-name }}'
 
     - name: Commit deletion of the branchpreview
       uses: EndBug/add-and-commit@v9.1.1
       with:
-        author_name: "${{ inputs.git-commit-author }}"
-        author_email: "${{ inputs.git-commit-email }}"
-        message: "Delete branchpreview ${{ inputs.repository-name }}:${{ inputs.branch-name }}"
+        author_name: '${{ inputs.git-commit-author }}'
+        author_email: '${{ inputs.git-commit-email }}'
+        message: 'Delete branchpreview ${{ inputs.repository-name }}:${{ inputs.branch-name }}'
         add: '["*.yaml","*.txt"]'
-        cwd: "${{ inputs.repo-branchpreviews-name }}"
+        cwd: '${{ inputs.repo-branchpreviews-name }}'
 
     # we need self-hosted runner only because of this step
     - name: Refresh Argo and wait for the deletion to be finished
@@ -94,6 +94,6 @@ runs:
       env:
         OPSSH_TARGETPATH: ${{ github.workspace }}/${{ inputs.repo-branchpreviews-name }}
       run: |
-        cd "${{ inputs.repo-branchpreview-templates-name }}"
-        ./Ops.sh refresh-branchpreviews "${{ inputs.argo-host }}" \
-          "${{ inputs.argo-sync-user-token }}"
+        cd '${{ inputs.repo-branchpreview-templates-name }}'
+        ./Ops.sh refresh-branchpreviews '${{ inputs.argo-host }}' \
+          '${{ inputs.argo-sync-user-token }}'

--- a/delete-featurenet/action.yml
+++ b/delete-featurenet/action.yml
@@ -47,7 +47,7 @@ runs:
       shell: bash
       run: |
         if [[
-          ! "${{ inputs.featurenet-name }}" =~ ^[a-z0-9][a-z0-9\-]{4,48}$
+          ! '${{ inputs.featurenet-name }}' =~ ^[a-z0-9][a-z0-9\-]{4,48}$
         ]]
         then
           echo "!!! Invalid feature net name"

--- a/get-node-system-version/action.yml
+++ b/get-node-system-version/action.yml
@@ -17,7 +17,7 @@ runs:
     - name: Validate action inputs
       shell: bash
       run: |
-        if [[ ${{ inputs.env }} != 'testnet' && ${{ inputs.env }} != 'mainnet' ]]; then
+        if [[ '${{ inputs.env }}' != 'testnet' && '${{ inputs.env }}' != 'mainnet' ]]; then
           echo "Error: inputs.env should be either mainnet or testnet!"
           exit 1
         fi
@@ -29,7 +29,7 @@ runs:
       run: |
         COMMIT_ID=$(curl -s -H "Content-Type: application/json" \
           -d '{"id":1, "jsonrpc":"2.0", "method": "system_version"}' \
-          "${{ inputs.env == 'mainnet' && 'https://rpc.azero.dev' || 'https://rpc.test.azero.dev' }}" \
+          '${{ inputs.env == 'mainnet' && 'https://rpc.azero.dev' || 'https://rpc.test.azero.dev' }}' \
           | jq -r '.result' | cut -d "-" -f 2 | head -c 7)
         echo "sha=$COMMIT_ID" >> $GITHUB_OUTPUT
       # yamllint enable rule:line-length

--- a/gh-deployments-environments/action.yml
+++ b/gh-deployments-environments/action.yml
@@ -46,7 +46,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       run: |
-        ${{ github.action_path }}/helper.sh create-deployment "${{ inputs.owner }}" "${{ inputs.repo }}" "${{ inputs.env }}" "${{ inputs.ref }}" "deployment-id.txt"
+        ${{ github.action_path }}/helper.sh create-deployment '${{ inputs.owner }}' '${{ inputs.repo }}' '${{ inputs.env }}' '${{ inputs.ref }}' 'deployment-id.txt'
 
         deployment_id=$(cat deployment-id.txt)
         if [[ "${deployment_id}" =~ ^[0-9]{1,32}$ ]]; then
@@ -64,7 +64,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       run: |
-        ${{ github.action_path }}/helper.sh create-deployment-status "${{ inputs.owner }}" "${{ inputs.repo }}" "${{ inputs.deployment-id }}" "${{ inputs.status }}"
+        ${{ github.action_path }}/helper.sh create-deployment-status '${{ inputs.owner }}' '${{ inputs.repo }}' '${{ inputs.deployment-id }}' '${{ inputs.status }}'
 
     - name: Delete environment
       id: delete-environment
@@ -73,4 +73,4 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.token }}
       run: |
-        ${{ github.action_path }}/helper.sh delete-environment "${{ inputs.owner }}" "${{ inputs.repo }}" "${{ inputs.env }}"
+        ${{ github.action_path }}/helper.sh delete-environment '${{ inputs.owner }}' '${{ inputs.repo }}' '${{ inputs.env }}'

--- a/yaml-lint/action.yml
+++ b/yaml-lint/action.yml
@@ -13,15 +13,15 @@ runs:
       shell: bash
       run: |
         if [[ -f .yamllint ]]; then
-          echo "file-path=.yamllint" >> $GITHUB_OUTPUT
+          echo 'file-path=.yamllint' >> $GITHUB_OUTPUT
         else
-          echo "file-path=${{ github.action_path }}/.yamllint" >> $GITHUB_OUTPUT
+          echo 'file-path=${{ github.action_path }}/.yamllint' >> $GITHUB_OUTPUT
         fi
 
     - name: Show .yamllint location
       shell: bash
       run: |
-        echo "Found .yamllint in ${{ steps.file-location.outputs.file-path }}"
+        echo 'Found .yamllint in ${{ steps.file-location.outputs.file-path }}'
 
     - name: LINT | Execute yaml-lint
       uses: ibiqlik/action-yamllint@v3.1.1


### PR DESCRIPTION
1. Makes create-branchpreview return all outputs which are encoded into one base64 string.
2. Replaces double quotes with single quotes so that backtick is not getting executed, in various places.  It would have been a bit risky to replace it everywhere and we'll do it in small chunks.  Also, inputs validation will be handled in another ticket.  Please note that `${{ something }}` is a github variable, not a bash one.  Hence it shouldn't have double quotes.
3. Replaces calling env vars with safe `'${{ env.VAR }}` in some places

## post-merge todo
* tag with new version, re-tag existing major v3 tag
* trigger featurenets test (though it runs nightly anyway)

## tests
outputs have been checked whilst working in common-frontend repo: https://github.com/Cardinal-Cryptography/common-frontend/actions/runs/6487830908/job/17619048437
