### PR TITLE
Bump github action validator from 0.4.4 to 0.5.0

### DIFF
--- a/yaml-validate/action.yml
+++ b/yaml-validate/action.yml
@@ -10,7 +10,7 @@ runs:
 
     - name: VALIDATE | Execute github-actions-validator
       env:
-        DOCKER_IMAGE: public.ecr.aws/p6e8q1z1/github-actions-validator:v0.4.4
+        DOCKER_IMAGE: public.ecr.aws/p6e8q1z1/github-actions-validator:v0.5.0
       shell: bash
       run: |
         set +e


### PR DESCRIPTION
Bumps github actions validator to recently created 0.5.0 that throws warnings on unnecessary double quotes used for github variables.