### PR TITLE
A0-2800 Make sure get-ref-propoerties.outputs.sha outputs 7 characters

### DIFF
--- a/get-ref-properties/action.yml
+++ b/get-ref-properties/action.yml
@@ -63,5 +63,5 @@ runs:
       id: commit
       shell: bash
       run: |
-        echo sha=$(git rev-parse --short HEAD) >> $GITHUB_OUTPUT
+        echo sha=$(git rev-parse --short=7 HEAD) >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
It might vary from repo to repo or from git version to git version that returned short commit id has different length. It happened on our `self-hosted` runners that it has 8 characters there, and all our public images on ECR have 7, hence this change.