### PR TITLE
A0-3645: Now performing git checkout Cardinal-Cryptography/aleph-node in get-aleph-node-fqdn-image/action.yml

### DIFF
--- a/get-aleph-node-fqdn-image/action.yml
+++ b/get-aleph-node-fqdn-image/action.yml
@@ -72,6 +72,7 @@ runs:
       if: ${{ inputs.ref != 'mainnet' && inputs.ref != 'testnet' }}
       uses: actions/checkout@v4
       with:
+        repository: Cardinal-Cryptography/aleph-node
         ref: ${{ inputs.ref }}
 
     - name: Get node commit SHA from input ref


### PR DESCRIPTION
This is a bug that manifests itself when calling `get-aleph-node-fqdn-image` action outside of `aleph-node` repository.