### PR TITLE
A0-3737: Support for dynamic sudo in FE bootstrap

### DIFF
--- a/.github/workflows/_featurenet-create.yml
+++ b/.github/workflows/_featurenet-create.yml
@@ -68,8 +68,7 @@ jobs:
             echo "!!! Invalid aleph-node image"
             exit 1
           fi
-          if [[ ! '${{ inputs.sudo-account-id }}' =~ ^[a-zA-Z0-9]{48}$ && \
-                '${{ inputs.sudo-account-id }}' != '//Alice' ]]; then
+          if [[ ! '${{ inputs.sudo-account-id }}' =~ ^[a-zA-Z0-9]{48}$ ]]; then
             echo "!!! Invalid sudo-account-id"
             exit 1
           fi

--- a/.github/workflows/_featurenet-create.yml
+++ b/.github/workflows/_featurenet-create.yml
@@ -116,7 +116,7 @@ jobs:
           debug: true
 
       - name: Upsert featurenet with image tag
-        uses: Cardinal-Cryptography/github-actions/create-featurenet@A0-3737
+        uses: Cardinal-Cryptography/github-actions/create-featurenet@v6
         id: create-featurenet
         with:
           gh-ci-user: ${{ secrets.CI_GH_USER }}

--- a/.github/workflows/_featurenet-create.yml
+++ b/.github/workflows/_featurenet-create.yml
@@ -43,7 +43,7 @@ on:
       sudo-account-id:
         description: 'Sudo account ID'
         type: string
-        required: false
+        required: true
         default: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
     outputs:
       ws-hostname:

--- a/.github/workflows/_featurenet-create.yml
+++ b/.github/workflows/_featurenet-create.yml
@@ -44,7 +44,7 @@ on:
         description: 'Sudo account ID'
         type: string
         required: false
-        default: '//Alice'
+        default: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
     outputs:
       ws-hostname:
         description: Hostname of the WS endpoint

--- a/.github/workflows/_featurenet-create.yml
+++ b/.github/workflows/_featurenet-create.yml
@@ -43,7 +43,7 @@ on:
       sudo-account-id:
         description: 'Sudo account ID'
         type: string
-        required: true
+        required: false
         default: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
     outputs:
       ws-hostname:

--- a/.github/workflows/_featurenet-create.yml
+++ b/.github/workflows/_featurenet-create.yml
@@ -40,6 +40,11 @@ on:
         required: false
         type: boolean
         default: false
+      sudo-account-id:
+        description: 'Sudo account ID'
+        type: string
+        required: false
+        default: '//Alice'
     outputs:
       ws-hostname:
         description: Hostname of the WS endpoint
@@ -61,6 +66,10 @@ jobs:
           fi
           if [[ ! '${{ inputs.aleph-node-image }}' =~ ^[a-z0-9][a-z0-9\._:/\-]{1,52}$ ]]; then
             echo "!!! Invalid aleph-node image"
+            exit 1
+          fi
+          if [[ ! '${{ inputs.sudo-account-id }}' =~ ^[a-zA-Z0-9]{48}$ ]]; then
+            echo "!!! Invalid sudo-account-id"
             exit 1
           fi
         # yamllint enable rule:line-length
@@ -123,6 +132,7 @@ jobs:
           git-commit-author: ${{ secrets.AUTOCOMMIT_AUTHOR }}
           git-commit-email: ${{ secrets.AUTOCOMMIT_EMAIL }}
           wait-for-finalized-heads: "true"
+          sudo-account-id: ${{ inputs.sudo-account-id }}
 
       - name: Finish featurenet Deployment
         uses: bobheadxi/deployments@v1

--- a/.github/workflows/_featurenet-create.yml
+++ b/.github/workflows/_featurenet-create.yml
@@ -116,7 +116,7 @@ jobs:
           debug: true
 
       - name: Upsert featurenet with image tag
-        uses: Cardinal-Cryptography/github-actions/create-featurenet@v6
+        uses: Cardinal-Cryptography/github-actions/create-featurenet@A0-3737
         id: create-featurenet
         with:
           gh-ci-user: ${{ secrets.CI_GH_USER }}

--- a/.github/workflows/_featurenet-create.yml
+++ b/.github/workflows/_featurenet-create.yml
@@ -68,7 +68,8 @@ jobs:
             echo "!!! Invalid aleph-node image"
             exit 1
           fi
-          if [[ ! '${{ inputs.sudo-account-id }}' =~ ^[a-zA-Z0-9]{48}$ ]]; then
+          if [[ ! '${{ inputs.sudo-account-id }}' =~ ^[a-zA-Z0-9]{48}$ && \
+                '${{ inputs.sudo-account-id }}' != '//Alice' ]]; then
             echo "!!! Invalid sudo-account-id"
             exit 1
           fi

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -58,7 +58,7 @@ inputs:
   sudo-account-id:
     description: 'Sudo account ID'
     required: false
-    default: '//Alice'
+    default: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
 outputs:
   ws-hostname:
     description: Hostname of the WS endpoint

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -55,6 +55,10 @@ inputs:
     description: 'Wait for heads finalization'
     required: false
     default: "false"
+  sudo-account-id:
+    description: 'Sudo account ID'
+    required: false
+    default: '//Alice'
 outputs:
   ws-hostname:
     description: Hostname of the WS endpoint
@@ -105,6 +109,10 @@ runs:
           echo "!!! Expected expiration to have values from set {3h, 12h, 24h, 48h, 96h, never}"
           exit 1
         fi
+        if [[ ! '${{ inputs.sudo-account-id }}' =~ ^[a-zA-Z0-9]{48}$ ]]; then
+          echo "!!! Invalid sudo-account-id"
+          exit 1
+        fi
 
     - name: Checkout featurenet template repo
       uses: actions/checkout@v3
@@ -133,6 +141,7 @@ runs:
           '${{ inputs.rolling-update-partition }}' \
           '${{ inputs.expiration }}' \
           ${{ inputs.internal == 'true' && '-i' || '' }} \
+          ${{ inputs.sudo-account-id != '' && '-s inputs.sudo-account-id' || '' }} \
           -c -g | tee -a tmp-opssh-createfeaturenet-output.txt
 
         ws_hostname=$(cat tmp-opssh-createfeaturenet-output.txt | grep '^__output:ws-hostname:' | cut -d: -f3)

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -109,7 +109,8 @@ runs:
           echo "!!! Expected expiration to have values from set {3h, 12h, 24h, 48h, 96h, never}"
           exit 1
         fi
-        if [[ ! '${{ inputs.sudo-account-id }}' =~ ^[a-zA-Z0-9]{48}$ ]]; then
+        if [[ ! '${{ inputs.sudo-account-id }}' =~ ^[a-zA-Z0-9]{48}$ && \
+              '${{ inputs.sudo-account-id }}' != '//Alice' ]]; then
           echo "!!! Invalid sudo-account-id"
           exit 1
         fi

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -57,7 +57,7 @@ inputs:
     default: "false"
   sudo-account-id:
     description: 'Sudo account ID'
-    required: true
+    required: false
     default: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
 outputs:
   ws-hostname:

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -120,8 +120,7 @@ runs:
         repository: Cardinal-Cryptography/${{ inputs.repo-featurenet-template-name }}
         token: ${{ inputs.gh-ci-token }}
         path: "${{ inputs.repo-featurenet-template-name }}"
-        # ref: main
-        ref: A0-3737
+        ref: main
 
     - name: Start featurenet
       id: start-featurenet

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -57,7 +57,7 @@ inputs:
     default: "false"
   sudo-account-id:
     description: 'Sudo account ID'
-    required: false
+    required: true
     default: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
 outputs:
   ws-hostname:

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -120,7 +120,8 @@ runs:
         repository: Cardinal-Cryptography/${{ inputs.repo-featurenet-template-name }}
         token: ${{ inputs.gh-ci-token }}
         path: "${{ inputs.repo-featurenet-template-name }}"
-        ref: main
+        # ref: main
+        ref: A0-3737
 
     - name: Start featurenet
       id: start-featurenet
@@ -140,8 +141,8 @@ runs:
           '${{ inputs.validators }}' \
           '${{ inputs.rolling-update-partition }}' \
           '${{ inputs.expiration }}' \
+          '${{ inputs.sudo-account-id }}' \
           ${{ inputs.internal == 'true' && '-i' || '' }} \
-          ${{ inputs.sudo-account-id != '' && '-s inputs.sudo-account-id' || '' }} \
           -c -g | tee -a tmp-opssh-createfeaturenet-output.txt
 
         ws_hostname=$(cat tmp-opssh-createfeaturenet-output.txt | grep '^__output:ws-hostname:' | cut -d: -f3)

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -109,8 +109,7 @@ runs:
           echo "!!! Expected expiration to have values from set {3h, 12h, 24h, 48h, 96h, never}"
           exit 1
         fi
-        if [[ ! '${{ inputs.sudo-account-id }}' =~ ^[a-zA-Z0-9]{48}$ && \
-              '${{ inputs.sudo-account-id }}' != '//Alice' ]]; then
+        if [[ ! '${{ inputs.sudo-account-id }}' =~ ^[a-zA-Z0-9]{48}$ ]]; then
           echo "!!! Invalid sudo-account-id"
           exit 1
         fi


### PR DESCRIPTION
Simple change, just passing `sudo-account-id` from inputs to `create-featurnet.sh`.

## Related PRs

https://github.com/Cardinal-Cryptography/featurenet-template/pull/19
https://github.com/Cardinal-Cryptography/aleph-node/pull/1551

## Post-merge steps

Retag `v6` 
