### PR TITLE
A0-3761: Extract updating featurenet to separate action and workflow

### DIFF
--- a/.github/workflows/_featurenet-create.yml
+++ b/.github/workflows/_featurenet-create.yml
@@ -116,7 +116,7 @@ jobs:
           debug: true
 
       - name: Create featurenet with image tag
-        uses: Cardinal-Cryptography/github-actions/create-featurenet@A0-3761-tweak-naming-for-more-clarity
+        uses: Cardinal-Cryptography/github-actions/create-featurenet@v5
         id: create-featurenet
         with:
           gh-ci-user: ${{ secrets.CI_GH_USER }}

--- a/.github/workflows/_featurenet-update.yml
+++ b/.github/workflows/_featurenet-update.yml
@@ -12,21 +12,6 @@ on:
         description: "FQDN of aleph-node image"
         required: true
         type: string
-      expiration:
-        description: 'Time after which featurenet will be removed: "Xh" or "never"'
-        required: false
-        type: string
-        default: 48h
-      validators:
-        description: 'Number of validators to start, from 0 to 50'
-        required: false
-        default: '5'
-        type: string
-      internal:
-        description: 'Internal network, accessible from VPN only'
-        required: false
-        type: boolean
-        default: false
       rolling-update-partition:
         description: |
           Number from 0 to N-1, where N is size of am existing featurenet.
@@ -35,16 +20,6 @@ on:
         required: false
         default: '0'
         type: string
-      delete-first:
-        description: 'Delete featurenet before upserting'
-        required: false
-        type: boolean
-        default: false
-      sudo-account-id:
-        description: 'Sudo account ID'
-        type: string
-        required: false
-        default: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
     outputs:
       ws-hostname:
         description: Hostname of the WS endpoint
@@ -68,10 +43,6 @@ jobs:
             echo "!!! Invalid aleph-node image"
             exit 1
           fi
-          if [[ ! '${{ inputs.sudo-account-id }}' =~ ^[a-zA-Z0-9]{48}$ ]]; then
-            echo "!!! Invalid sudo-account-id"
-            exit 1
-          fi
         # yamllint enable rule:line-length
 
   check-vars-and-secrets:
@@ -91,20 +62,6 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      - name: Delete old featurenet app and data
-        if: ${{ inputs.delete-first == true }}
-        uses: Cardinal-Cryptography/github-actions/delete-featurenet@v5
-        with:
-          gh-ci-user: ${{ secrets.CI_GH_USER }}
-          gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
-          aws-access-key-id: ${{ secrets.AWS_DEVNET_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_DEVNET_SECRET_ACCESS_KEY }}
-          argo-sync-user-token: ${{ secrets.ARGO_SYNC_USER_TOKEN }}
-          repo-featurenet-template-name: ${{ secrets.REPO_FEATURENET_TEMPLATE_NAME }}
-          featurenet-name: ${{ inputs.featurenet-name }}
-          git-commit-author: ${{ secrets.AUTOCOMMIT_AUTHOR }}
-          git-commit-email: ${{ secrets.AUTOCOMMIT_EMAIL }}
-
       - name: Start featurenet Deployment
         uses: bobheadxi/deployments@v1.1.0
         id: deployment
@@ -115,8 +72,8 @@ jobs:
           override: true
           debug: true
 
-      - name: Create featurenet with image tag
-        uses: Cardinal-Cryptography/github-actions/create-featurenet@A0-3761-tweak-naming-for-more-clarity
+      - name: Update featurenet with image tag
+        uses: Cardinal-Cryptography/github-actions/update-featurenet@A0-3761-tweak-naming-for-more-clarity
         id: create-featurenet
         with:
           gh-ci-user: ${{ secrets.CI_GH_USER }}
@@ -125,14 +82,10 @@ jobs:
           repo-featurenet-template-name: ${{ secrets.REPO_FEATURENET_TEMPLATE_NAME }}
           featurenet-name: ${{ inputs.featurenet-name }}
           featurenet-aleph-node-image: ${{ inputs.aleph-node-image }}
-          expiration: ${{ inputs.expiration }}
-          validators: ${{ inputs.validators }}
-          internal: ${{ inputs.internal && 'true' || 'false' }}
           rolling-update-partition: ${{ inputs.rolling-update-partition }}
           git-commit-author: ${{ secrets.AUTOCOMMIT_AUTHOR }}
           git-commit-email: ${{ secrets.AUTOCOMMIT_EMAIL }}
           wait-for-finalized-heads: "true"
-          sudo-account-id: ${{ inputs.sudo-account-id }}
 
       - name: Finish featurenet Deployment
         uses: bobheadxi/deployments@v1

--- a/.github/workflows/_featurenet-update.yml
+++ b/.github/workflows/_featurenet-update.yml
@@ -73,7 +73,7 @@ jobs:
           debug: true
 
       - name: Update featurenet with image tag
-        uses: Cardinal-Cryptography/github-actions/update-featurenet@A0-3761-tweak-naming-for-more-clarity
+        uses: Cardinal-Cryptography/github-actions/update-featurenet@v5
         id: create-featurenet
         with:
           gh-ci-user: ${{ secrets.CI_GH_USER }}

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -120,7 +120,7 @@ runs:
         repository: Cardinal-Cryptography/${{ inputs.repo-featurenet-template-name }}
         token: ${{ inputs.gh-ci-token }}
         path: "${{ inputs.repo-featurenet-template-name }}"
-        ref: A0-3761-tweak-naming-for-more-clarity
+        ref: main
 
     - name: Start featurenet
       id: start-featurenet

--- a/update-featurenet/action.yml
+++ b/update-featurenet/action.yml
@@ -82,7 +82,7 @@ runs:
         repository: Cardinal-Cryptography/${{ inputs.repo-featurenet-template-name }}
         token: ${{ inputs.gh-ci-token }}
         path: "${{ inputs.repo-featurenet-template-name }}"
-        ref: A0-3761-tweak-naming-for-more-clarity
+        ref: main
 
     - name: Start featurenet
       id: start-featurenet

--- a/update-featurenet/action.yml
+++ b/update-featurenet/action.yml
@@ -31,10 +31,6 @@ inputs:
     description: 'aleph-node docker image tag'
     required: true
     default: ''
-  expiration:
-    description: 'Time after which updatenet will be removed'
-    required: false
-    default: ''
   rolling-update-partition:
     description: |
       Number from 0 to N-1, where N is size of am existing featurenet.
@@ -42,23 +38,10 @@ inputs:
       will be updated. If not specified, all nodes will be updated.
     required: false
     default: "0"
-  validators:
-    description: |
-      Number of validators to start, from 0 to 50.
-    required: false
-    default: "5"
-  internal:
-    description: 'Internal network, accessible from VPN only'
-    required: false
-    default: "false"
   wait-for-finalized-heads:
     description: 'Wait for heads finalization'
     required: false
     default: "false"
-  sudo-account-id:
-    description: 'Sudo account ID'
-    required: false
-    default: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY'
 outputs:
   ws-hostname:
     description: Hostname of the WS endpoint
@@ -92,27 +75,6 @@ runs:
           echo "!!! Expected rolling update partition to be a cardinal value from 0 to 9"
           exit 1
         fi
-        if [[
-          '${{ inputs.validators }}' != "" && \
-          ! '${{ inputs.validators }}' =~ ^[0-9]{1,2}$ || '${{ inputs.validators }}' -gt 50
-        ]]
-        then
-          echo "!!! Expected validators to be a cardinal value from 0 to 50"
-          exit 1
-        fi
-        if [[
-          '${{ inputs.expiration }}' != "" && \
-          ! '${{ inputs.expiration }}' =~ ^[0-9]{1,6}h$ && \
-          '${{ inputs.expiration }}' != "never"
-        ]]
-        then
-          echo "!!! Expected expiration to have values from set {3h, 12h, 24h, 48h, 96h, never}"
-          exit 1
-        fi
-        if [[ ! '${{ inputs.sudo-account-id }}' =~ ^[a-zA-Z0-9]{48}$ ]]; then
-          echo "!!! Invalid sudo-account-id"
-          exit 1
-        fi
 
     - name: Checkout featurenet template repo
       uses: actions/checkout@v3
@@ -137,14 +99,14 @@ runs:
         ./upsert-featurenet.sh \
           '${{ inputs.featurenet-name }}' \
           '${{ inputs.featurenet-aleph-node-image }}' \
-          '${{ inputs.validators }}' \
+          'not-used-because-update' \
           '${{ inputs.rolling-update-partition }}' \
-          '${{ inputs.expiration }}' \
-          '${{ inputs.sudo-account-id }}' \
-          ${{ inputs.internal == 'true' && '-i' || '' }} \
-          -c -g | tee -a tmp-opssh-createfeaturenet-output.txt
+          'not-used-because-update' \
+          'not-used-because-update' \
+          -u \
+          -c -g | tee -a tmp-opssh-updatefeaturenet-output.txt
 
-        ws_hostname=$(cat tmp-opssh-createfeaturenet-output.txt | grep '^__output:ws-hostname:' | cut -d: -f3)
+        ws_hostname=$(cat tmp-opssh-updatefeaturenet-output.txt | grep '^__output:ws-hostname:' | cut -d: -f3)
         echo "ws-hostname=${ws_hostname}" >> $GITHUB_OUTPUT
       # yamllint enable rule:line-length
 


### PR DESCRIPTION
### pre-merge steps
Remove all occurences of `A0-3761-tweak-naming-for-more-clarity` branch and revert to `v6` or `main`.

### post-merge steps
Tag with `v6.3.0` and re-tag `v6`.

### test result
https://github.com/Cardinal-Cryptography/ops-scripts/actions/runs/7673480177