### PR TITLE
A0-3158: Add if-exists input to copy-file-to-s3 action

### DIFF
--- a/copy-file-to-s3/action.yml
+++ b/copy-file-to-s3/action.yml
@@ -22,7 +22,7 @@ inputs:
     description: Set to 'true' to compress file into a .tar.gz archive
     required: false
     default: 'true'
-  if-exists:
+  if-exist:
     description: Action to be taken when destination file already exists, one of 'skip', 'overwrite' or 'fail'
     required: false
     default: 'skip'
@@ -33,11 +33,11 @@ runs:
       shell: bash
       run: |
         if [[
-          '${{ inputs.if-exists }}' != 'skip' && \
-          '${{ inputs.if-exists }}' != 'overwrite' && \
-          '${{ inputs.if-exists }}' != 'fail'
+          '${{ inputs.if-exist }}' != 'skip' && \
+          '${{ inputs.if-exist }}' != 'overwrite' && \
+          '${{ inputs.if-exist }}' != 'fail'
         ]]; then
-          echo "!!! Invalid value for 'if-exists' argument, should be one of 'skip', 'overwrite' or 'fail'"
+          echo "!!! Invalid value for 'if-exist' argument, should be one of 'skip', 'overwrite' or 'fail'"
           exit 1
         fi
 
@@ -87,11 +87,11 @@ runs:
         if [[ "${not_exist}" != 'true' ]]; then
           echo '! File ${{ inputs.s3-bucket-filename }} already exists on S3 bucket.'
 
-          if [[ '${{ inputs.if-exists }}' == 'fail' ]]; then
+          if [[ '${{ inputs.if-exist }}' == 'fail' ]]; then
             echo '! Failing.'
             exit 1
           fi
-          if [[ '${{ inputs.if-exists }}' != 'overwrite' ]]; then
+          if [[ '${{ inputs.if-exist }}' != 'overwrite' ]]; then
             echo '! Skipping overwrite.'
             exit 0
           fi

--- a/copy-file-to-s3/action.yml
+++ b/copy-file-to-s3/action.yml
@@ -22,12 +22,25 @@ inputs:
     description: Set to 'true' to compress file into a .tar.gz archive
     required: false
     default: 'true'
+  if-exists:
+    description: Action to be taken when destination file already exists, one of 'skip', 'overwrite' or 'fail'
+    required: false
+    default: 'skip'
 runs:
   using: composite
   steps:
     - name: Copy file to S3 AWS bucket
       shell: bash
       run: |
+        if [[
+          '${{ inputs.if-exists }}' != 'skip' && \
+          '${{ inputs.if-exists }}' != 'overwrite' && \
+          '${{ inputs.if-exists }}' != 'fail'
+        ]]; then
+          echo "!!! Invalid value for 'if-exists' argument, should be one of 'skip', 'overwrite' or 'fail'"
+          exit 1
+        fi
+
         if [[
           '${{ inputs.compression }}' == 'true' && \
           '${{ inputs.source-filename }}' == '${{ inputs.s3-bucket-filename }}'
@@ -70,17 +83,29 @@ runs:
           --bucket '${{ inputs.s3-bucket-name }}' \
           --key '${{ inputs.s3-bucket-path }}/${{ inputs.s3-bucket-filename }}' \
           2> /dev/null || not_exist=true
-        if [[ "${not_exist}" ]]; then
-          target_s3_filepath='${{ inputs.s3-bucket-path }}/${{ inputs.s3-bucket-filename }}'
-          if [[ '${{ inputs.compression}}' == 'true' ]]; then
-            tar -cvzf '${{ inputs.s3-bucket-filename }}' -C '${{ inputs.source-path }}' \
-              '${{ inputs.source-filename }}'
-            aws s3 cp '${{ inputs.s3-bucket-filename }}' \
-              s3://${{ inputs.s3-bucket-name }}/"${target_s3_filepath}"
-          else
-            aws s3 cp '${{ inputs.source-path }}' \
-              s3://${{ inputs.s3-bucket-name }}/"${target_s3_filepath}"
+
+        if [[ "${not_exist}" != 'true' ]]; then
+          if [[ '${{ inputs.if-exists }}' == 'fail' ]]; then
+            echo '! File ${{ inputs.s3-bucket-filename }} already exists on S3 bucket.'
+            echo '! Failing.'
+            exit 1
           fi
+          if [[ '${{ inputs.if-exists }}' != 'overwrite' ]]; then
+            echo '! File ${{ inputs.s3-bucket-filename }} already exists on S3 bucket.'
+            echo '! Skipping overwrite.'
+            exit 0
+          fi
+
+          echo '! Overwriting.'
+        fi
+
+        target_s3_filepath='${{ inputs.s3-bucket-path }}/${{ inputs.s3-bucket-filename }}'
+        if [[ '${{ inputs.compression}}' == 'true' ]]; then
+          tar -cvzf '${{ inputs.s3-bucket-filename }}' -C '${{ inputs.source-path }}' \
+            '${{ inputs.source-filename }}'
+          aws s3 cp '${{ inputs.s3-bucket-filename }}' \
+            s3://${{ inputs.s3-bucket-name }}/"${target_s3_filepath}"
         else
-          echo 'File ${{ inputs.s3-bucket-filename }} already exists on S3 bucket.'
+          aws s3 cp '${{ inputs.source-path }}' \
+            s3://${{ inputs.s3-bucket-name }}/"${target_s3_filepath}"
         fi

--- a/copy-file-to-s3/action.yml
+++ b/copy-file-to-s3/action.yml
@@ -85,13 +85,13 @@ runs:
           2> /dev/null || not_exist=true
 
         if [[ "${not_exist}" != 'true' ]]; then
+          echo '! File ${{ inputs.s3-bucket-filename }} already exists on S3 bucket.'
+
           if [[ '${{ inputs.if-exists }}' == 'fail' ]]; then
-            echo '! File ${{ inputs.s3-bucket-filename }} already exists on S3 bucket.'
             echo '! Failing.'
             exit 1
           fi
           if [[ '${{ inputs.if-exists }}' != 'overwrite' ]]; then
-            echo '! File ${{ inputs.s3-bucket-filename }} already exists on S3 bucket.'
             echo '! Skipping overwrite.'
             exit 0
           fi

--- a/copy-file-to-s3/action.yml
+++ b/copy-file-to-s3/action.yml
@@ -23,7 +23,7 @@ inputs:
     required: false
     default: 'true'
   if-exist:
-    description: Action to be taken when destination file already exists, one of 'skip', 'overwrite' or 'fail'
+    description: Action to be taken when destination file already exists, one of 'skip', 'overwrite' or 'fallback'
     required: false
     default: 'skip'
 runs:
@@ -35,9 +35,9 @@ runs:
         if [[
           '${{ inputs.if-exist }}' != 'skip' && \
           '${{ inputs.if-exist }}' != 'overwrite' && \
-          '${{ inputs.if-exist }}' != 'fail'
+          '${{ inputs.if-exist }}' != 'fallback'
         ]]; then
-          echo "!!! Invalid value for 'if-exist' argument, should be one of 'skip', 'overwrite' or 'fail'"
+          echo "!!! Invalid value for 'if-exist' argument, should be one of 'skip', 'overwrite' or 'fallback'"
           exit 1
         fi
 
@@ -87,11 +87,11 @@ runs:
         if [[ "${not_exist}" != 'true' ]]; then
           echo '! File ${{ inputs.s3-bucket-filename }} already exists on S3 bucket.'
 
-          if [[ '${{ inputs.if-exist }}' == 'fail' ]]; then
+          if [[ '${{ inputs.if-exist }}' == 'fallback' ]]; then
             echo '! Failing.'
             exit 1
           fi
-          if [[ '${{ inputs.if-exist }}' != 'overwrite' ]]; then
+          if [[ '${{ inputs.if-exist }}' == 'skip' ]]; then
             echo '! Skipping overwrite.'
             exit 0
           fi


### PR DESCRIPTION
Modifies `copy-file-to-s3` action by introducing an input called `if-exist` to specify what should happen when file already exists on S3 bucket.  The default behaviour so far has been to skip the `cp` command, and we'll leave it that way.  However, it is possible to tell the action to either overwrite or fail.

Change is required for one of the workflows in Most.