### PR TITLE
A0-4085: Add step that posts frontend-url when branchpreview is created

### DIFF
--- a/.github/workflows/_branchpreview-create.yml
+++ b/.github/workflows/_branchpreview-create.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - name: Create branchpreview
         id: create-branchpreview
-        uses: Cardinal-Cryptography/github-actions/create-branchpreview@A0-4085-add-posting-frontend-url-when-branchpreview-is-created
+        uses: Cardinal-Cryptography/github-actions/create-branchpreview@v6
         with:
           repository-name: ${{ inputs.repository-name }}
           branch-name: ${{ inputs.branch-name }}

--- a/.github/workflows/_branchpreview-create.yml
+++ b/.github/workflows/_branchpreview-create.yml
@@ -20,6 +20,16 @@ on:
         description: "Choose from 'private' or 'public'"
         required: true
         type: string
+      post-frontend-url:
+        description: "Post frontend-url output to PR comments"
+        required: false
+        type: string
+        default: "false"
+      pull-request-number:
+        description: "Pull request number required when posting frontend-url"
+        required: false
+        type: string
+        default: ""
     outputs:
       base64:
         description: Outputs encoded with base64
@@ -54,3 +64,5 @@ jobs:
           git-commit-author: ${{ secrets.AUTOCOMMIT_AUTHOR }}
           git-commit-email: ${{ secrets.AUTOCOMMIT_EMAIL }}
           hard-refresh: 'true'
+          post-frontend-url: '${{ inputs.post-frontend-url }}'
+          pull-request-number: '${{ inputs.pull-request-number }}'

--- a/.github/workflows/_branchpreview-create.yml
+++ b/.github/workflows/_branchpreview-create.yml
@@ -50,7 +50,7 @@ jobs:
     steps:
       - name: Create branchpreview
         id: create-branchpreview
-        uses: Cardinal-Cryptography/github-actions/create-branchpreview@v3
+        uses: Cardinal-Cryptography/github-actions/create-branchpreview@A0-4085-add-posting-frontend-url-when-branchpreview-is-created
         with:
           repository-name: ${{ inputs.repository-name }}
           branch-name: ${{ inputs.branch-name }}

--- a/create-branchpreview/action.yml
+++ b/create-branchpreview/action.yml
@@ -36,6 +36,14 @@ inputs:
     description: 'Make hard-refresh of ArgoCD application'
     required: false
     default: "false"
+  post-frontend-url:
+    description: "Post frontend-url output value"
+    required: false
+    default: "false"
+  pull-request-number:
+    description: "Pull request number to post the frontend-url to"
+    required: false
+    default: ""
 outputs:
   app-name:
     description: |
@@ -131,3 +139,21 @@ runs:
           '${{ inputs.argo-sync-user-token }}' \
           '${{ steps.start-branchpreview.outputs.app-name }}' \
           '${{ inputs.hard-refresh == 'true' && 'true' || 'false' }}'
+
+    - name: Post frontend-url in comments
+      if: >
+        inputs.post-frontend-url == 'true' &&
+        inputs.repository-name != '' &&
+        inputs.pull-request-number != ''
+      env:
+        CI_GH_TOKEN: ${{ inputs.gh-ci-token }}
+      run: |
+        echo '${{ steps.start-branchpreview.outputs.all-base64 }}' | base64 -d > tmp-outputs.txt
+        frontend_url=$(cat tmp-outputs.txt | grep "^frontend-url" | sed 's|frontend-url:||g')
+        curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ env.CI_GH_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/Cardinal-Cryptography/${{ inputs.repository-name }}/issues/${{ inputs.pull-request-number }}/comments \
+            -d "{\"body\":\"The following site has been deployed: [${frontend_url}](${frontend_url})\"}"

--- a/create-branchpreview/action.yml
+++ b/create-branchpreview/action.yml
@@ -145,6 +145,7 @@ runs:
         inputs.post-frontend-url == 'true' &&
         inputs.repository-name != '' &&
         inputs.pull-request-number != ''
+      shell: bash
       env:
         CI_GH_TOKEN: ${{ inputs.gh-ci-token }}
       run: |


### PR DESCRIPTION
Adds a step that posts frontend URL of a branchpreview as a pull request comment.  The code is copied over from other repositories.

It's been tested and works as expected.