### PR TITLE
A0-4267: Make "install rust toolchain" action install components

### DIFF
--- a/install-rust-toolchain/action.yml
+++ b/install-rust-toolchain/action.yml
@@ -75,7 +75,8 @@ runs:
       run: |
         components=$(echo ${{ env.COMPONENTS }} | tr -d '[]' | sed 's/,/ /g')
         for component in $components; do
-          rustup component add $component
+          rustup component add $component \
+          --toolchain ${{ steps.install-rust-toolchain.outputs.channel }}
         done
 
     - name: Add targets (optional)


### PR DESCRIPTION
Currently the step that adds components uses default toolchain instead of the one provided as argument. This PR fixes the bug.