### PR TITLE
A0-4268: Support for chain-bootstrapper in actions

### DIFF
--- a/.github/workflows/_featurenet-create.yml
+++ b/.github/workflows/_featurenet-create.yml
@@ -101,7 +101,7 @@ jobs:
 
       - name: Delete old featurenet app and data
         if: ${{ inputs.delete-first == true }}
-        uses: Cardinal-Cryptography/github-actions/delete-featurenet@v6
+        uses: Cardinal-Cryptography/github-actions/delete-featurenet@v7
         with:
           gh-ci-user: ${{ secrets.CI_GH_USER }}
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
@@ -124,7 +124,7 @@ jobs:
           debug: true
 
       - name: Create featurenet with image tag
-        uses: Cardinal-Cryptography/github-actions/create-featurenet@A0-4268
+        uses: Cardinal-Cryptography/github-actions/create-featurenet@v7
         id: create-featurenet
         with:
           gh-ci-user: ${{ secrets.CI_GH_USER }}

--- a/.github/workflows/_featurenet-create.yml
+++ b/.github/workflows/_featurenet-create.yml
@@ -124,7 +124,7 @@ jobs:
           debug: true
 
       - name: Create featurenet with image tag
-        uses: Cardinal-Cryptography/github-actions/create-featurenet@v6
+        uses: Cardinal-Cryptography/github-actions/create-featurenet@A0-4268
         id: create-featurenet
         with:
           gh-ci-user: ${{ secrets.CI_GH_USER }}

--- a/.github/workflows/_featurenet-create.yml
+++ b/.github/workflows/_featurenet-create.yml
@@ -72,7 +72,7 @@ jobs:
             echo "!!! Invalid aleph-node image"
             exit 1
           fi
-          if [[ ! '${{ inputs.chain-bootstrapper-image }}' =~ ^[a-z0-9][a-z0-9\._:/\-]{1,52}$ ]]; then
+          if [[ ! '${{ inputs.chain-bootstrapper-image }}' =~ ^[a-z0-9][a-z0-9\._:/\-]{1,56}$ ]]; then
             echo "!!! Invalid chain-bootstrapper image"
             exit 1
           fi

--- a/.github/workflows/_featurenet-create.yml
+++ b/.github/workflows/_featurenet-create.yml
@@ -12,6 +12,10 @@ on:
         description: "FQDN of aleph-node image"
         required: true
         type: string
+      chain-bootstrapper-image:
+        description: "FQDN of chain-bootstrapper image"
+        required: true
+        type: string
       expiration:
         description: 'Time after which featurenet will be removed: "Xh" or "never"'
         required: false
@@ -66,6 +70,10 @@ jobs:
           fi
           if [[ ! '${{ inputs.aleph-node-image }}' =~ ^[a-z0-9][a-z0-9\._:/\-]{1,52}$ ]]; then
             echo "!!! Invalid aleph-node image"
+            exit 1
+          fi
+          if [[ ! '${{ inputs.chain-bootstrapper-image }}' =~ ^[a-z0-9][a-z0-9\._:/\-]{1,52}$ ]]; then
+            echo "!!! Invalid chain-bootstrapper image"
             exit 1
           fi
           if [[ ! '${{ inputs.sudo-account-id }}' =~ ^[a-zA-Z0-9]{48}$ ]]; then
@@ -125,6 +133,7 @@ jobs:
           repo-featurenet-template-name: ${{ secrets.REPO_FEATURENET_TEMPLATE_NAME }}
           featurenet-name: ${{ inputs.featurenet-name }}
           featurenet-aleph-node-image: ${{ inputs.aleph-node-image }}
+          featurenet-chain-bootstrapper-image: ${{ inputs.chain-bootstrapper-image }}
           expiration: ${{ inputs.expiration }}
           validators: ${{ inputs.validators }}
           internal: ${{ inputs.internal && 'true' || 'false' }}

--- a/.github/workflows/_featurenet-delete.yml
+++ b/.github/workflows/_featurenet-delete.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Delete featurenet app and data
-        uses: Cardinal-Cryptography/github-actions/delete-featurenet@v6
+        uses: Cardinal-Cryptography/github-actions/delete-featurenet@v7
         with:
           gh-ci-user: ${{ secrets.CI_GH_USER }}
           gh-ci-token: ${{ secrets.CI_GH_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
       - name: Delete environment
         # yamllint disable-line rule:line-length
         if: ${{ matrix.updatenet-gh-env != 'devnet' && matrix.updatenet-gh-env != 'testnet' && matrix.updatenet-gh-env != 'mainnet' }}
-        uses: Cardinal-Cryptography/github-actions/gh-deployments-environments@v6
+        uses: Cardinal-Cryptography/github-actions/gh-deployments-environments@v7
         with:
           action: delete-environment
           env: ${{ inputs.featurenet-name }}

--- a/.github/workflows/_featurenet-update.yml
+++ b/.github/workflows/_featurenet-update.yml
@@ -73,7 +73,7 @@ jobs:
           debug: true
 
       - name: Update featurenet with image tag
-        uses: Cardinal-Cryptography/github-actions/update-featurenet@v6
+        uses: Cardinal-Cryptography/github-actions/update-featurenet@A0-4268
         id: create-featurenet
         with:
           gh-ci-user: ${{ secrets.CI_GH_USER }}

--- a/.github/workflows/_featurenet-update.yml
+++ b/.github/workflows/_featurenet-update.yml
@@ -73,7 +73,7 @@ jobs:
           debug: true
 
       - name: Update featurenet with image tag
-        uses: Cardinal-Cryptography/github-actions/update-featurenet@A0-4268
+        uses: Cardinal-Cryptography/github-actions/update-featurenet@v7
         id: create-featurenet
         with:
           gh-ci-user: ${{ secrets.CI_GH_USER }}

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -89,7 +89,7 @@ runs:
           exit 1
         fi
         if [[
-          ! '${{ inputs.featurenet-chain-bootstrapper-image }}' =~ ^[a-z0-9][a-z0-9\._/:\-]{1,52}$
+          ! '${{ inputs.featurenet-chain-bootstrapper-image }}' =~ ^[a-z0-9][a-z0-9\._/:\-]{1,56}$
         ]]
         then
           echo "!!! Invalid featurenet chain-bootstrapper image tag"

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -131,7 +131,7 @@ runs:
         repository: Cardinal-Cryptography/${{ inputs.repo-featurenet-template-name }}
         token: ${{ inputs.gh-ci-token }}
         path: "${{ inputs.repo-featurenet-template-name }}"
-        ref: A0-4268
+        ref: main
 
     - name: Start featurenet
       id: start-featurenet

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'aleph-node docker image tag'
     required: true
     default: ''
+  featurenet-chain-bootstrapper-image:
+    description: 'chain-bootstrapper docker image tag'
+    required: true
+    default: ''
   expiration:
     description: 'Time after which updatenet will be removed'
     required: false
@@ -82,6 +86,13 @@ runs:
         ]]
         then
           echo "!!! Invalid featurenet node image tag"
+          exit 1
+        fi
+        if [[
+          ! '${{ inputs.featurenet-chain-bootstrapper-image }}' =~ ^[a-z0-9][a-z0-9\._/:\-]{1,52}$
+        ]]
+        then
+          echo "!!! Invalid featurenet chain-bootstrapper image tag"
           exit 1
         fi
         if [[
@@ -141,6 +152,8 @@ runs:
           '${{ inputs.rolling-update-partition }}' \
           '${{ inputs.expiration }}' \
           '${{ inputs.sudo-account-id }}' \
+          'not-used' \
+          '${{ inputs.featurenet-chain-bootstrapper-image }}'
           ${{ inputs.internal == 'true' && '-i' || '' }} \
           -c -g | tee -a tmp-opssh-createfeaturenet-output.txt
 

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -153,7 +153,7 @@ runs:
           '${{ inputs.expiration }}' \
           '${{ inputs.sudo-account-id }}' \
           'not-used' \
-          '${{ inputs.featurenet-chain-bootstrapper-image }}'
+          '${{ inputs.featurenet-chain-bootstrapper-image }}' \
           ${{ inputs.internal == 'true' && '-i' || '' }} \
           -c -g | tee -a tmp-opssh-createfeaturenet-output.txt
 

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -131,7 +131,7 @@ runs:
         repository: Cardinal-Cryptography/${{ inputs.repo-featurenet-template-name }}
         token: ${{ inputs.gh-ci-token }}
         path: "${{ inputs.repo-featurenet-template-name }}"
-        ref: main
+        ref: A0-4268
 
     - name: Start featurenet
       id: start-featurenet

--- a/get-aleph-node-fqdn-image/action.yml
+++ b/get-aleph-node-fqdn-image/action.yml
@@ -218,7 +218,7 @@ runs:
         chain_bootstrapper_fqdn_image='not-required'
         chain_bootstrapper_fqdn_image_latest='not-required'
         chain_bootstrapper_image_exists='true'
-        if [[ '${{ steps.steps.check-chain-bootstrapper-crate-existence.outputs.exists }}' == 'true' ]]; then
+        if [[ '${{ steps.check-chain-bootstrapper-crate-existence.outputs.exists }}' == 'true' ]]; then
           chain_bootstrapper_image_exists='${{ steps.check-chain-bootstrapper-image-exists.outputs.image-exists }}'
           chain_bootstrapper_fqdn_image='${{ steps.compose-chain-bootstrapper-fqdn-node-image.outputs.fqdn-image }}'
           chain_bootstrapper_fqdn_image_latest='${{ steps.compose-chain-bootstrapper-fqdn-node-image.outputs.fqdn-image-latest }}'

--- a/get-aleph-node-fqdn-image/action.yml
+++ b/get-aleph-node-fqdn-image/action.yml
@@ -97,6 +97,13 @@ runs:
       with:
         env: ${{ inputs.ref }}
 
+    - name: Checkout aleph-node from net ref
+      if: ${{ inputs.ref == 'mainnet' || inputs.ref == 'testnet' }}
+      uses: actions/checkout@v4
+      with:
+        repository: Cardinal-Cryptography/aleph-node
+        ref: ${{ steps.get-node-commit-sha-from-net.outputs.sha }}
+
     - name: Checkout aleph-node from input ref
       if: ${{ inputs.ref != 'mainnet' && inputs.ref != 'testnet' }}
       uses: actions/checkout@v4

--- a/get-aleph-node-fqdn-image/action.yml
+++ b/get-aleph-node-fqdn-image/action.yml
@@ -175,7 +175,7 @@ runs:
       id: check-chain-bootstrapper-crate-existence
       shell: bash
       run: |
-        if cargo metadata --offline | jq -e '.packages[] | select(.name=="chain-bootstrapper")' > /dev/null; then
+        if cargo metadata | jq -e '.packages[] | select(.name=="chain-bootstrapper")' > /dev/null; then
           echo "exists=true" >> $GITHUB_OUTPUT
         else
           echo "exists=false" >> $GITHUB_OUTPUT

--- a/get-aleph-node-fqdn-image/action.yml
+++ b/get-aleph-node-fqdn-image/action.yml
@@ -1,8 +1,7 @@
 ---
 name: Get aleph-node FQDN docker image for featurenets
 description:
-  This action compiles fully qualified aleph node domain name of aleph-node image. It is currently
-  used only in the context of featurenets.
+  This action compiles fully qualified aleph node domain name of aleph-node image. 
 
   This name depends on whether
     * it is test binary or production binary,
@@ -11,10 +10,17 @@ description:
   There's spacial logic when searching for a production binary that cannot be found in the
   production ECR repo - we assume it can be found as well in dev ECR repo, as long session
   aleph-node binaries not build from main or release branches are not release candidates
+  
+  Alongisde with aleph-node FQDN, this action outputs as well chain-bootstrapper FQDN that
+  was built from the same commit SHA as aleph-node.  
 
-  Convention of naming aleph-node images is as follows
-    * short session binaries are named aleph-node:<sha>-dev
-    * normal session binaries are named aleph-node:<sha>
+  Convention of naming aleph-node and chain-bootstrapper images is as follows
+    * aleph-node images are named
+      ** testing profile binaries aleph-node:<sha>-dev
+      ** production profile binaries aleph-node:<sha>
+    * chain-bootstrapper images are named
+      ** testing profile binaries chain-bootstrapper:<sha>-dev
+      ** production profile binaries chain-bootstrapper:<sha>
 inputs:
   ref:
     description: "aleph-node repo's git ref: hash, branch, tag - or 'mainnet' or 'testnet'"
@@ -28,16 +34,35 @@ inputs:
   ecr-prod-node-repo:
     description: 'URL and name of aleph-node prod ECR repo'
     required: true
+  ecr-chain-bootstrapper-repo:
+    description: 'URL and name of chain-bootstrapper ECR repo'
+    required: true
+  only-aleph-nope-production-repo:
+    description: "Set to true to use only ECR aleph-node production repo"
+    required: false
+    default: 'true'
 outputs:
   fqdn-image:
     description: 'FQDN path to aleph-node ECR docker image.'
     value: ${{ steps.combine-action-outputs.outputs.fqdn-image }}
+  fqdn-image-latest:
+    description: 'FQDN path to aleph-node ECR docker latest image.'
+    value: ${{ steps.combine-action-outputs.outputs.fqdn-image-latest }}
+  chain-bootstrapper-fqdn-image:
+    description: 'FQDN path to chain-bootstrapper ECR docker image.'
+    value: ${{ steps.combine-action-outputs.outputs.chain-bootstrapper-fqdn-image }}
+  chain-bootstrapper-fqdn-image-latest:
+    description: 'FQDN path to chain-bootstrapper ECR docker latest image.'
+    value: ${{ steps.combine-action-outputs.outputs.chain-bootstrapper-fqdn-image-latest }}
   ref:
     description: 'An aleph-node git ref to build image from.'
     value: ${{ steps.combine-action-outputs.outputs.ref }}
   image-exists:
-    description: 'True if aleph-node image does not exist on ECR '
+    description: 'true if aleph-node image does not exist on ECR, otherwise false'
     value: ${{ steps.combine-action-outputs.outputs.image-exists }}
+  chain-bootstrapper-image-exists:
+    description: 'true if chain-bootstrapper image does not exist on ECR, otherwise false'
+    value: ${{ steps.combine-action-outputs.outputs.chain-bootstrapper-image-exists }}
 runs:
   using: composite
   steps:
@@ -58,6 +83,10 @@ runs:
         fi
         if [[ -z '${{ inputs.ecr-prod-node-repo }}' ]]; then
           echo "!!! ecr-prod-node-repo is empty"
+          exit 1
+        fi
+        if [[ -z '${{ inputs.ecr-chain-bootstrapper-repo }}' ]]; then
+          echo "!!! ecr-chain-bootstrapper-repo is empty"
           exit 1
         fi
 
@@ -99,6 +128,8 @@ runs:
       run: |
         fqdn_image='${{ env.ECR_REPO }}:${{ env.SHA }}${{ env.TAG_SUFFIX }}'
         echo "fqdn-image=${fqdn_image}" >> $GITHUB_OUTPUT
+        fqdn_image_latest='${{ env.ECR_REPO }}:latest'
+        echo "fqdn-image-latest=${fqdn_image_latest}" >> $GITHUB_OUTPUT
         ref='${{ env.FULL_SHA }}'
         echo "ref=${ref}" >> $GITHUB_OUTPUT
 
@@ -114,6 +145,7 @@ runs:
       id: compose-fqdn-prod-node-image-in-dev-repo
       if: ${{ steps.check-fqdn-docker-image-existence.outputs.image-exists == 'false' &&
               inputs.test-binary == 'false' &&
+              inputs.only-aleph-nope-production-repo != 'true' &&
               inputs.ref != 'mainnet' && inputs.ref != 'testnet' }}
       env:
         ECR_REPO: ${{ inputs.ecr-dev-node-repo }}
@@ -132,6 +164,42 @@ runs:
         ecr-image: ${{ steps.compose-fqdn-prod-node-image-in-dev-repo.outputs.fqdn-image }}
         exit-when-image-not-exists: 'false'
 
+    - name: Check if chain-bootstrapper crate exists
+      id: check-chain-bootstrapper-crate-existence
+      shell: bash
+      run: |
+        if cargo metadata | jq -e '.packages[] | select(.name=="chain-bootstrapper")' > /dev/null; then
+          echo "exists=true" >> $GITHUB_OUTPUT
+        else
+          echo "exists=false" >> $GITHUB_OUTPUT
+        fi
+
+    - name: Compose chain-bootstrapper fqdn docker image
+      id: compose-chain-bootstrapper-fqdn-node-image
+      if: ${{ steps.check-chain-bootstrapper-crate-existence.outputs.exists == 'true' }}
+      env:
+        ECR_REPO: ${{ inputs.ecr-chain-bootstrapper-repo }}
+        TAG_SUFFIX: ${{ inputs.test-binary == 'true' &&
+          '-dev' ||
+          '' }}
+        SHA: ${{ (inputs.ref == 'mainnet' || inputs.ref == 'testnet') &&
+          steps.get-node-commit-sha-from-net.outputs.sha ||
+          steps.get-node-commit-sha-from-ref.outputs.sha }}
+      shell: bash
+      run: |
+        fqdn_image='${{ env.ECR_REPO }}:${{ env.SHA }}${{ env.TAG_SUFFIX }}'
+        echo "fqdn-image=${fqdn_image}" >> $GITHUB_OUTPUT
+        fqdn_image_latest='${{ env.ECR_REPO }}:latest'
+        echo "fqdn-image-latest=${fqdn_image_latest}" >> $GITHUB_OUTPUT
+
+    - name: Check chain-bootstrapper fqdn docker image in ECR repo existence
+      id: check-chain-bootstrapper-image-exists
+      if: ${{ steps.check-chain-bootstrapper-crate-existence.outputs.exists == 'true' }}
+      uses: Cardinal-Cryptography/github-actions/check-image-existence-ecr@v6
+      with:
+        ecr-image: ${{ steps.compose-chain-bootstrapper-fqdn-node-image.outputs.fqdn-image }}
+        exit-when-image-not-exists: 'false'
+
     - name: Combine action outputs
       id: combine-action-outputs
       shell: bash
@@ -141,14 +209,26 @@ runs:
         if [[ '${{ steps.compose-fqdn-prod-node-image-in-dev-repo.outputs.fqdn-image }}' != '' ]]; then
           fqdn_image='${{ steps.compose-fqdn-prod-node-image-in-dev-repo.outputs.fqdn-image }}'
         fi
+        fqdn_image_latest='${{ steps.compose-fqdn-node-image.outputs.fqdn-image-latest }}'
         ref='${{ steps.compose-fqdn-node-image.outputs.ref }}'
         image_exists='${{ steps.check-fqdn-docker-image-existence.outputs.image-exists }}'
         if [[ '${{ steps.check-fqdn-prod-node-image-in-dev-repo.outputs.image-exists }}' != '' ]]; then
           image_exists='${{ steps.check-fqdn-prod-node-image-in-dev-repo.outputs.image-exists }}'
         fi
+        chain_bootstrapper_fqdn_image='not-required'
+        chain_bootstrapper_fqdn_image_latest='not-required'
+        chain_bootstrapper_image_exists='true'
+        if [[ '${{ steps.steps.check-chain-bootstrapper-crate-existence.outputs.exists }}' == 'true' ]]; then
+          chain_bootstrapper_image_exists='${{ steps.check-chain-bootstrapper-image-exists.outputs.image-exists }}'
+          chain_bootstrapper_fqdn_image='${{ steps.compose-chain-bootstrapper-fqdn-node-image.outputs.fqdn-image }}'
+          chain_bootstrapper_fqdn_image_latest='${{ steps.compose-chain-bootstrapper-fqdn-node-image.outputs.fqdn-image-latest }}'
+        fi
+        
         echo "fqdn-image=${fqdn_image}" >> $GITHUB_OUTPUT
+        echo "fqdn-image-latest=${fqdn_image_latest}" >> $GITHUB_OUTPUT
         echo "ref=${ref}" >> $GITHUB_OUTPUT
         echo "image-exists=${image_exists}" >> $GITHUB_OUTPUT
+        echo "chain-bootstrapper-image-exists=${chain_bootstrapper_image_exists}" >> $GITHUB_OUTPUT
+        echo "chain-bootstrapper-fqdn-image=${chain_bootstrapper_fqdn_image}" >> $GITHUB_OUTPUT
+        echo "chain-bootstrapper-fqdn-image-latest=${chain_bootstrapper_fqdn_image_latest}" >> $GITHUB_OUTPUT
       # yamllint enable rule:line-length
-
-

--- a/get-aleph-node-fqdn-image/action.yml
+++ b/get-aleph-node-fqdn-image/action.yml
@@ -102,7 +102,7 @@ runs:
       uses: actions/checkout@v4
       with:
         repository: Cardinal-Cryptography/aleph-node
-        ref: ${{ steps.get-node-commit-sha-from-net.outputs.sha }}
+        ref: ${{ steps.get-node-commit-sha-from-net.outputs.full-sha }}
 
     - name: Checkout aleph-node from input ref
       if: ${{ inputs.ref != 'mainnet' && inputs.ref != 'testnet' }}

--- a/get-aleph-node-fqdn-image/action.yml
+++ b/get-aleph-node-fqdn-image/action.yml
@@ -175,7 +175,7 @@ runs:
       id: check-chain-bootstrapper-crate-existence
       shell: bash
       run: |
-        if cargo metadata | jq -e '.packages[] | select(.name=="chain-bootstrapper")' > /dev/null; then
+        if cargo metadata --offline | jq -e '.packages[] | select(.name=="chain-bootstrapper")' > /dev/null; then
           echo "exists=true" >> $GITHUB_OUTPUT
         else
           echo "exists=false" >> $GITHUB_OUTPUT

--- a/get-node-system-version/action.yml
+++ b/get-node-system-version/action.yml
@@ -25,12 +25,6 @@ runs:
           exit 1
         fi
 
-    - name: Checkout aleph-node repo with full depth
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        repository: Cardinal-Cryptography/aleph-node
-
     - name: Query RPC system.version
       id: rpc-system-version
       shell: bash

--- a/update-featurenet/action.yml
+++ b/update-featurenet/action.yml
@@ -82,7 +82,7 @@ runs:
         repository: Cardinal-Cryptography/${{ inputs.repo-featurenet-template-name }}
         token: ${{ inputs.gh-ci-token }}
         path: "${{ inputs.repo-featurenet-template-name }}"
-        ref: main
+        ref: A0-4268
 
     - name: Start featurenet
       id: start-featurenet

--- a/update-featurenet/action.yml
+++ b/update-featurenet/action.yml
@@ -82,7 +82,7 @@ runs:
         repository: Cardinal-Cryptography/${{ inputs.repo-featurenet-template-name }}
         token: ${{ inputs.gh-ci-token }}
         path: "${{ inputs.repo-featurenet-template-name }}"
-        ref: A0-4268
+        ref: main
 
     - name: Start featurenet
       id: start-featurenet

--- a/update-featurenet/action.yml
+++ b/update-featurenet/action.yml
@@ -103,6 +103,8 @@ runs:
           '${{ inputs.rolling-update-partition }}' \
           'not-used-because-update' \
           'not-used-because-update' \
+          'not-used-because-update' \
+          'not-used-because-update' \
           -u \
           -c -g | tee -a tmp-opssh-updatefeaturenet-output.txt
 


### PR DESCRIPTION
This PR adds generating FQDN image for new crate `chain-bootstrapper`.

Actions before merge: replace all `A0-4268` references to `main` and bump all `v6` to `v7`. 
Actions after merge: add `v7` tag.

Companion PRs:
https://github.com/Cardinal-Cryptography/featurenet-template/pull/30
https://github.com/Cardinal-Cryptography/aleph-node/pull/1720