### PR TITLE
A0-2999: Update all actions to run on node20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+---
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: sunday
+      # UTC time
+      time: "06:15"
+    rebase-strategy: disabled
+    commit-message:
+      prefix: "A0-3952: "
+    groups:
+      all-github-actions:
+        patterns:
+          - "*"
+    pull-request-branch-name:
+      separator: "-"
+    reviewers:
+      - "Marcin-Radecki"
+      - "Mikolaj Gasior"
+

--- a/.github/workflows/_featurenet-create.yml
+++ b/.github/workflows/_featurenet-create.yml
@@ -106,7 +106,7 @@ jobs:
           git-commit-email: ${{ secrets.AUTOCOMMIT_EMAIL }}
 
       - name: Start featurenet Deployment
-        uses: bobheadxi/deployments@v1.1.0
+        uses: bobheadxi/deployments@v1
         id: deployment
         with:
           step: start

--- a/.github/workflows/_featurenet-update.yml
+++ b/.github/workflows/_featurenet-update.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Start featurenet Deployment
-        uses: bobheadxi/deployments@v1.1.0
+        uses: bobheadxi/deployments@v1
         id: deployment
         with:
           step: start

--- a/create-branchpreview/action.yml
+++ b/create-branchpreview/action.yml
@@ -79,7 +79,7 @@ runs:
         fi
 
     - name: Checkout branchpreviews repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Cardinal-Cryptography/${{ inputs.repo-branchpreviews-name }}
         token: ${{ inputs.gh-ci-token }}
@@ -87,7 +87,7 @@ runs:
         ref: main
 
     - name: Checkout branchpreview templates repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Cardinal-Cryptography/${{ inputs.repo-branchpreview-templates-name }}
         token: ${{ inputs.gh-ci-token }}

--- a/create-featurenet/action.yml
+++ b/create-featurenet/action.yml
@@ -115,7 +115,7 @@ runs:
         fi
 
     - name: Checkout featurenet template repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Cardinal-Cryptography/${{ inputs.repo-featurenet-template-name }}
         token: ${{ inputs.gh-ci-token }}

--- a/delete-branchpreview/action.yml
+++ b/delete-branchpreview/action.yml
@@ -54,7 +54,7 @@ runs:
         fi
 
     - name: Checkout branchpreviews repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Cardinal-Cryptography/${{ inputs.repo-branchpreviews-name }}
         token: ${{ inputs.gh-ci-token }}
@@ -62,7 +62,7 @@ runs:
         ref: main
 
     - name: Checkout branchpreview templates repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Cardinal-Cryptography/${{ inputs.repo-branchpreview-templates-name }}
         token: ${{ inputs.gh-ci-token }}

--- a/delete-featurenet/action.yml
+++ b/delete-featurenet/action.yml
@@ -46,7 +46,7 @@ runs:
         fi
 
     - name: Checkout featurenet template repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Cardinal-Cryptography/${{ inputs.repo-featurenet-template-name }}
         token: ${{ inputs.gh-ci-token }}
@@ -54,7 +54,7 @@ runs:
         ref: main
 
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v2
+      uses: aws-actions/configure-aws-credentials@v4
       env:
         AWS_REGION: us-east-1
       with:

--- a/install-rust-toolchain/action.yml
+++ b/install-rust-toolchain/action.yml
@@ -35,21 +35,21 @@ runs:
 
     - name: Read channel from rust-toolchain.toml
       id: toolchain-channel
-      uses: SebRollen/toml-action@v1.0.2
+      uses: SebRollen/toml-action@v1.2.0
       with:
         file: 'rust-toolchain.toml'
         field: 'toolchain.channel'
 
     - name: Read components from rust-toolchain.toml
       id: toolchain-components
-      uses: SebRollen/toml-action@v1.0.2
+      uses: SebRollen/toml-action@v1.2.0
       with:
         file: 'rust-toolchain.toml'
         field: 'toolchain.components'
 
     - name: Read targets from rust-toolchain.toml
       id: toolchain-targets
-      uses: SebRollen/toml-action@v1.0.2
+      uses: SebRollen/toml-action@v1.2.0
       with:
         file: 'rust-toolchain.toml'
         field: 'toolchain.targets'

--- a/slack-notification/action.yml
+++ b/slack-notification/action.yml
@@ -22,7 +22,7 @@ runs:
   using: 'composite'
   steps:
     - name: Get workflow conclusion
-      uses: technote-space/workflow-conclusion-action@v3
+      uses: Cardinal-Cryptography/workflow-conclusion-action@v3
 
     - name: Export envs
       shell: bash

--- a/update-featurenet/action.yml
+++ b/update-featurenet/action.yml
@@ -77,7 +77,7 @@ runs:
         fi
 
     - name: Checkout featurenet template repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: Cardinal-Cryptography/${{ inputs.repo-featurenet-template-name }}
         token: ${{ inputs.gh-ci-token }}

--- a/yaml-lint/action.yml
+++ b/yaml-lint/action.yml
@@ -6,7 +6,7 @@ runs:
   using: "composite"
   steps:
     - name: GIT | Checkout source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: Get .yamllint location
       id: file-location

--- a/yaml-validate/action.yml
+++ b/yaml-validate/action.yml
@@ -6,7 +6,7 @@ runs:
   using: "composite"
   steps:
     - name: GIT | Checkout source code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: VALIDATE | Execute github-actions-validator
       env:


### PR DESCRIPTION
See https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/ for more info.

Additionally, this change introduces dependabot. It makes sense to run it in this repo, as it is a common GHA code for all repos in an org. Quite a few actions were already outdated.